### PR TITLE
add spawn egg filtering

### DIFF
--- a/src/main/java/dev/plex/listener/impl/SpawnEggListener.java
+++ b/src/main/java/dev/plex/listener/impl/SpawnEggListener.java
@@ -1,0 +1,56 @@
+package dev.plex.listener.impl;
+
+import dev.plex.listener.PlexListener;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+import java.util.List;
+
+public class SpawnEggListener extends PlexListener
+{
+    public static List<Material> SPAWN_EGGS;
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onPlayerInteract(PlayerInteractEvent event)
+    {
+        if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK)
+        {
+            if (SPAWN_EGGS.contains(event.getMaterial()))
+            {
+                event.setCancelled(true);
+                Block clickedBlock = event.getClickedBlock();
+                if (clickedBlock == null)
+                {
+                    return;
+                }
+                EntityType eggType = null;
+                try
+                {
+                    Material mat = event.getMaterial();
+                    if (mat == Material.MOOSHROOM_SPAWN_EGG)
+                    {
+                        eggType = EntityType.MUSHROOM_COW;
+                    }
+                    else
+                    {
+                        eggType = EntityType.valueOf(mat.name().substring(0, mat.name().length() - 10));
+                    }
+                }
+                catch (IllegalArgumentException ignored)
+                {
+                    //
+                }
+                if (eggType != null)
+                {
+                    clickedBlock.getWorld().spawnEntity(clickedBlock.getLocation().add(event.getBlockFace().getDirection()).add(0.5, 0.5, 0.5), eggType);
+                }
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/dev/plex/services/ServiceManager.java
+++ b/src/main/java/dev/plex/services/ServiceManager.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import dev.plex.Plex;
 import dev.plex.services.impl.BanService;
 import dev.plex.services.impl.GameRuleService;
+import dev.plex.services.impl.SpawnEggService;
 import dev.plex.services.impl.UpdateCheckerService;
 import java.util.List;
 import org.bukkit.Bukkit;
@@ -17,6 +18,7 @@ public class ServiceManager
         registerService(new BanService());
         registerService(new GameRuleService());
         registerService(new UpdateCheckerService());
+        registerService(new SpawnEggService());
     }
 
     public void startServices()

--- a/src/main/java/dev/plex/services/impl/SpawnEggService.java
+++ b/src/main/java/dev/plex/services/impl/SpawnEggService.java
@@ -1,0 +1,24 @@
+package dev.plex.services.impl;
+
+import dev.plex.listener.impl.SpawnEggListener;
+import dev.plex.services.AbstractService;
+import org.bukkit.Material;
+
+import java.util.Arrays;
+
+public class SpawnEggService extends AbstractService
+{
+    public SpawnEggService() {
+        super(false, true);
+    }
+
+    @Override
+    public void run() {
+        SpawnEggListener.SPAWN_EGGS = Arrays.stream(Material.values()).filter((mat) -> mat.name().endsWith("_SPAWN_EGG")).toList();
+    }
+
+    @Override
+    public int repeatInSeconds() {
+        return 0;
+    }
+}


### PR DESCRIPTION
when placed, all spawn eggs will instead manually spawn the entity rather than actually letting the server handle the right click.

**todo:** dispensers, spawners, spawner minecarts, armorstands?