### PR TITLE
MiniMessage & prefix handling improvement

### DIFF
--- a/server/src/main/java/dev/plex/listener/impl/ChatListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/ChatListener.java
@@ -9,6 +9,7 @@ import io.papermc.paper.chat.ChatRenderer;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -59,7 +60,7 @@ public class ChatListener extends PlexListener
         @Override
         public @NotNull Component render(@NotNull Player source, @NotNull Component sourceDisplayName, @NotNull Component message, @NotNull Audience viewer)
         {
-            message = message.replaceText(URL_REPLACEMENT_CONFIG);
+            String text = ((TextComponent)message).content();
 
             if (hasPrefix)
             {
@@ -70,14 +71,16 @@ public class ChatListener extends PlexListener
                         .append(Component.space())
                         .append(Component.text("»").color(NamedTextColor.GRAY))
                         .append(Component.space())
-                        .append(message);
+                        .append(PlexUtils.mmDeserialize(text))
+                        .replaceText(URL_REPLACEMENT_CONFIG);
             }
             return Component.empty()
                     .append(PlexUtils.mmDeserialize(plugin.config.getString("chat.name-color", "<white>") + MiniMessage.builder().tags(TagResolver.resolver(StandardTags.color(), StandardTags.rainbow(), StandardTags.decorations(), StandardTags.gradient(), StandardTags.transition())).build().serialize(sourceDisplayName)))
                     .append(Component.space())
                     .append(Component.text("»").color(NamedTextColor.GRAY))
                     .append(Component.space())
-                    .append(message);
+                    .append(PlexUtils.mmDeserialize(text))
+                    .replaceText(URL_REPLACEMENT_CONFIG);
         }
     }
 }

--- a/server/src/main/java/dev/plex/listener/impl/ChatListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/ChatListener.java
@@ -61,20 +61,15 @@ public class ChatListener extends PlexListener
         public @NotNull Component render(@NotNull Player source, @NotNull Component sourceDisplayName, @NotNull Component message, @NotNull Audience viewer)
         {
             String text = ((TextComponent)message).content();
+            Component component = Component.empty();
 
             if (hasPrefix)
             {
-                return Component.empty()
-                        .append(prefix)
-                        .append(Component.space())
-                        .append(PlexUtils.mmDeserialize(plugin.config.getString("chat.name-color", "<white>") + MiniMessage.builder().tags(TagResolver.resolver(StandardTags.color(), StandardTags.rainbow(), StandardTags.decorations(), StandardTags.gradient(), StandardTags.transition())).build().serialize(sourceDisplayName)))
-                        .append(Component.space())
-                        .append(Component.text("»").color(NamedTextColor.GRAY))
-                        .append(Component.space())
-                        .append(PlexUtils.mmDeserialize(text))
-                        .replaceText(URL_REPLACEMENT_CONFIG);
+                component = component.append(prefix);
             }
-            return Component.empty()
+
+            return component
+                    .append(Component.space())
                     .append(PlexUtils.mmDeserialize(plugin.config.getString("chat.name-color", "<white>") + MiniMessage.builder().tags(TagResolver.resolver(StandardTags.color(), StandardTags.rainbow(), StandardTags.decorations(), StandardTags.gradient(), StandardTags.transition())).build().serialize(sourceDisplayName)))
                     .append(Component.space())
                     .append(Component.text("»").color(NamedTextColor.GRAY))


### PR DESCRIPTION
Changes:
- Use a variable for the chat component & if they have a prefix, append the prefix to that variable instead of using else if (done)
- Allow players to use MiniMessage in their chat messages (done)
- Allow players to use MiniMessage in books (not done)
- Allow players to use MiniMessage in item lore & names (not done)
- Allow players to use MiniMessage in tags (done)