### PR TITLE
Make getNonNullPlayer work with UUIDs too

### DIFF
--- a/server/src/main/java/dev/plex/command/PlexCommand.java
+++ b/server/src/main/java/dev/plex/command/PlexCommand.java
@@ -566,10 +566,13 @@ public abstract class PlexCommand extends Command implements PluginIdentifiableC
 
     protected Player getNonNullPlayer(String name)
     {
-        try {
+        try
+        {
             UUID uuid = UUID.fromString(name);
             return Bukkit.getPlayer(uuid);
-        } catch (IllegalArgumentException ignored) {
+        }
+        catch (IllegalArgumentException ignored)
+        {
 
         }
 

--- a/server/src/main/java/dev/plex/command/PlexCommand.java
+++ b/server/src/main/java/dev/plex/command/PlexCommand.java
@@ -566,6 +566,13 @@ public abstract class PlexCommand extends Command implements PluginIdentifiableC
 
     protected Player getNonNullPlayer(String name)
     {
+        try {
+            UUID uuid = UUID.fromString(name);
+            return Bukkit.getPlayer(uuid);
+        } catch (IllegalArgumentException ignored) {
+
+        }
+
         Player player = Bukkit.getPlayer(name);
         if (player == null)
         {


### PR DESCRIPTION
This allows commands like /mute to be used with UUIDs