### PR TITLE
Fix the string sanitisation blocking CJK, Russian and other alphabets

### DIFF
--- a/server/src/main/java/dev/plex/listener/impl/TogglesListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/TogglesListener.java
@@ -2,6 +2,7 @@ package dev.plex.listener.impl;
 
 import dev.plex.listener.PlexListener;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockFromToEvent;
 import org.bukkit.event.block.BlockRedstoneEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
@@ -11,11 +12,20 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 public class TogglesListener extends PlexListener
 {
     @EventHandler
-    public void onBlockExplode(ExplosionPrimeEvent event)
+    public void onExplosionPrime(ExplosionPrimeEvent event)
     {
         if (!plugin.toggles.getBoolean("explosions"))
         {
             event.getEntity().remove();
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onBlockExplode(BlockExplodeEvent event) {
+        if (!plugin.toggles.getBoolean("explosions"))
+        {
+            event.getBlock().breakNaturally();
             event.setCancelled(true);
         }
     }

--- a/server/src/main/java/dev/plex/util/PlexUtils.java
+++ b/server/src/main/java/dev/plex/util/PlexUtils.java
@@ -281,6 +281,6 @@ public class PlexUtils implements PlexBase
 
     public static String cleanString(String input)
     {
-        return CharMatcher.forPredicate(c -> Character.getDirectionality(c) != Character.DIRECTIONALITY_RIGHT_TO_LEFT_OVERRIDE || Character.getDirectionality(c) != Character.DIRECTIONALITY_RIGHT_TO_LEFT).retainFrom(input);
+        return CharMatcher.forPredicate(c -> Character.getDirectionality(c) != Character.DIRECTIONALITY_RIGHT_TO_LEFT_OVERRIDE && Character.getDirectionality(c) != Character.DIRECTIONALITY_RIGHT_TO_LEFT).retainFrom(input);
     }
 }

--- a/server/src/main/java/dev/plex/util/PlexUtils.java
+++ b/server/src/main/java/dev/plex/util/PlexUtils.java
@@ -281,6 +281,6 @@ public class PlexUtils implements PlexBase
 
     public static String cleanString(String input)
     {
-        return CharMatcher.ascii().retainFrom(input);
+        return CharMatcher.forPredicate(c -> Character.getDirectionality(c) != Character.DIRECTIONALITY_RIGHT_TO_LEFT_OVERRIDE || Character.getDirectionality(c) != Character.DIRECTIONALITY_RIGHT_TO_LEFT).retainFrom(input);
     }
 }


### PR DESCRIPTION
This should fix an issue where you cant type anything Chinese for example, it only filters characters with the Right to left directionality or right to left override directionality