### PR TITLE
Fix string sanitising (whoopsies)

### DIFF
--- a/server/src/main/java/dev/plex/util/PlexUtils.java
+++ b/server/src/main/java/dev/plex/util/PlexUtils.java
@@ -281,6 +281,6 @@ public class PlexUtils implements PlexBase
 
     public static String cleanString(String input)
     {
-        return CharMatcher.ascii().retainFrom(input);
+        return CharMatcher.forPredicate(c -> Character.getDirectionality(c) != Character.DIRECTIONALITY_RIGHT_TO_LEFT_OVERRIDE && Character.getDirectionality(c) != Character.DIRECTIONALITY_RIGHT_TO_LEFT).retainFrom(input);
     }
 }


### PR DESCRIPTION
This should fix an issue where you cant type anything Chinese for example, it only filters characters with the Right to left directionality or right to left override directionality

NOTICE: I had too much trouble (I don't use git often) squashing the commit on my branch so I just decided to remake this.