### PR TITLE
Fixed /mp and it now has the ability to purge one or all mobs + tab completion.

### DIFF
--- a/server/src/main/java/dev/plex/command/impl/EntityWipeCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/EntityWipeCMD.java
@@ -20,11 +20,9 @@ import java.util.*;
 
 @CommandPermissions(permission = "plex.entitywipe", source = RequiredCommandSource.ANY)
 @CommandParameters(name = "entitywipe", description = "Remove various server entities that may cause lag, such as dropped items, minecarts, and boats.", usage = "/<command> [entity] [radius]", aliases = "ew,rd")
-public class EntityWipeCMD extends PlexCommand
-{
+public class EntityWipeCMD extends PlexCommand {
     @Override
-    protected Component execute(@NotNull CommandSender sender, @Nullable Player playerSender, @NotNull String[] args)
-    {
+    protected Component execute(@NotNull CommandSender sender, @Nullable Player playerSender, @NotNull String[] args) {
         List<String> entityBlacklist = plugin.config.getStringList("entitywipe_list");
 
         List<String> entityWhitelist = new LinkedList<>(Arrays.asList(args));
@@ -36,8 +34,7 @@ public class EntityWipeCMD extends PlexCommand
         PlexLog.debug("using blacklist: " + useBlacklist);
         PlexLog.debug("radius specified: " + radiusSpecified);
 
-        if (radiusSpecified)
-        {
+        if (radiusSpecified) {
             radius = parseInt(sender, args[entityWhitelist.size() - 1]); // get the args length as the size of the list
             radius *= radius;
             entityWhitelist.remove(entityWhitelist.size() - 1); // remove the radius from the list
@@ -49,8 +46,7 @@ public class EntityWipeCMD extends PlexCommand
         entityWhitelist.removeIf(name ->
         {
             boolean res = Arrays.stream(entityTypes).noneMatch(entityType -> name.equalsIgnoreCase(entityType.name()));
-            if (res)
-            {
+            if (res) {
                 sender.sendMessage(messageComponent("invalidEntityType", name));
             }
             return res;
@@ -58,21 +54,15 @@ public class EntityWipeCMD extends PlexCommand
 
         HashMap<String, Integer> entityCounts = new HashMap<>();
 
-        for (World world : Bukkit.getWorlds())
-        {
-            for (Entity entity : world.getEntities())
-            {
-                if (entity.getType() != EntityType.PLAYER)
-                {
+        for (World world : Bukkit.getWorlds()) {
+            for (Entity entity : world.getEntities()) {
+                if (entity.getType() != EntityType.PLAYER) {
                     String type = entity.getType().name();
 
-                    if (useBlacklist ? entityBlacklist.stream().noneMatch(entityName -> entityName.equalsIgnoreCase(type)) : entityWhitelist.stream().anyMatch(entityName -> entityName.equalsIgnoreCase(type)))
-                    {
-                        if (radius > 0)
-                        {
+                    if (useBlacklist ? entityBlacklist.stream().noneMatch(entityName -> entityName.equalsIgnoreCase(type)) : entityWhitelist.stream().anyMatch(entityName -> entityName.equalsIgnoreCase(type))) {
+                        if (radius > 0) {
                             PlexLog.debug("we got here, radius is > 0");
-                            if (playerSender != null && entity.getWorld() == playerSender.getWorld() && playerSender.getLocation().distanceSquared(entity.getLocation()) > radius)
-                            {
+                            if (playerSender != null && entity.getWorld() == playerSender.getWorld() && playerSender.getLocation().distanceSquared(entity.getLocation()) > radius) {
                                 PlexLog.debug("continuing");
                                 continue;
                             }
@@ -88,14 +78,10 @@ public class EntityWipeCMD extends PlexCommand
 
         int entityCount = entityCounts.values().stream().mapToInt(a -> a).sum();
 
-        if (useBlacklist)
-        {
+        if (useBlacklist) {
             PlexUtils.broadcast(messageComponent("removedEntities", sender.getName(), entityCount));
-        }
-        else
-        {
-            if (entityCount == 0)
-            {
+        } else {
+            if (entityCount == 0) {
                 sender.sendMessage(messageComponent("noRemovedEntities"));
                 return null;
             }
@@ -106,15 +92,11 @@ public class EntityWipeCMD extends PlexCommand
         return null;
     }
 
-    public @NotNull List<String> tabComplete(@NotNull CommandSender sender, @NotNull String alias, @NotNull String[] args) throws IllegalArgumentException
-    {
+    public @NotNull List<String> tabComplete(@NotNull CommandSender sender, @NotNull String alias, @NotNull String[] args) throws IllegalArgumentException {
         List<String> entities = new ArrayList<>();
-        for (World world : Bukkit.getWorlds())
-        {
-            for (Entity entity : world.getEntities())
-            {
-                if (entity.getType() != EntityType.PLAYER)
-                {
+        for (World world : Bukkit.getWorlds()) {
+            for (Entity entity : world.getEntities()) {
+                if (entity.getType() != EntityType.PLAYER) {
                     entities.add(entity.getType().name());
                 }
             }
@@ -122,31 +104,22 @@ public class EntityWipeCMD extends PlexCommand
         return entities.stream().toList();
     }
 
-    private Integer parseInt(CommandSender sender, String string)
-    {
-        try
-        {
+    private Integer parseInt(CommandSender sender, String string) {
+        try {
             return Integer.parseInt(string);
-        }
-        catch (NumberFormatException ex)
-        {
+        } catch (NumberFormatException ex) {
             sender.sendMessage(mmString("<red>" + string + "<red> is not a valid number!"));
         }
         return null;
     }
 
-    private boolean isNumeric(String string)
-    {
-        if (string == null)
-        {
+    private boolean isNumeric(String string) {
+        if (string == null) {
             return false;
         }
-        try
-        {
+        try {
             int num = Integer.parseInt(string);
-        }
-        catch (NumberFormatException nfe)
-        {
+        } catch (NumberFormatException nfe) {
             return false;
         }
         return true;

--- a/server/src/main/java/dev/plex/command/impl/MobPurgeCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/MobPurgeCMD.java
@@ -4,35 +4,33 @@ import dev.plex.command.PlexCommand;
 import dev.plex.command.annotation.CommandParameters;
 import dev.plex.command.annotation.CommandPermissions;
 import dev.plex.command.source.RequiredCommandSource;
-
 import dev.plex.util.PlexUtils;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
+import java.util.*;
 
 @CommandPermissions(permission = "plex.mobpurge", source = RequiredCommandSource.ANY)
-@CommandParameters(name = "mobpurge", description = "Purge all mobs.", usage = "/<command>", aliases = "mp")
-public class MobPurgeCMD extends PlexCommand
-{
+@CommandParameters(name = "mobpurge", description = "Purge all mobs.", usage = "/<command> <mob>", aliases = "mp")
+public class MobPurgeCMD extends PlexCommand {
+
+    public static final List<EntityType> MOB_TYPES = new ArrayList<>();
+
     @Override
-    protected Component execute(@NotNull CommandSender sender, @Nullable Player playerSender, @NotNull String[] args)
-    {
+    protected Component execute(@NotNull CommandSender sender, @Nullable Player playerSender, @NotNull String[] args) {
         HashMap<String, Integer> entityCounts = new HashMap<>();
 
-        for (World world : Bukkit.getWorlds())
-        {
-            for (Entity entity : world.getEntities())
-            {
-                if (entity instanceof Mob)
-                {
+        for (World world : Bukkit.getWorlds()) {
+            for (Entity entity : world.getEntities()) {
+                if (entity instanceof Mob) {
                     String type = entity.getType().name();
                     entity.remove();
 
@@ -49,5 +47,23 @@ public class MobPurgeCMD extends PlexCommand
             sender.sendMessage(messageComponent("removedEntitiesOfType", sender.getName(), numRemoved, entityName));
         });*/
         return null;
+    }
+
+    // Adds a tab completion for /mp so players stop complaining we (mostly me) nuked all their mobs because a filter for some reason was never added by the REAL plex devs. Go figure. -Alco_Rs11
+
+    public static List<String> getAllMobs() {
+        List<String> mobs = new ArrayList<>();
+        Arrays.stream(EntityType.values()).filter(EntityType::isAlive).filter(EntityType::isSpawnable).forEach(MOB_TYPES::add);
+        for (EntityType entityType : MOB_TYPES) {
+            mobs.add(entityType.name());
+        }
+        return mobs;
+    }
+
+    public @NotNull List<String> tabComplete(@NotNull CommandSender sender, @NotNull String alias, @NotNull String[] args) throws IllegalArgumentException {
+        if (args.length == 1) {
+            return getAllMobs();
+        }
+        return Collections.emptyList();
     }
 }

--- a/server/src/main/java/dev/plex/command/impl/MobPurgeCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/MobPurgeCMD.java
@@ -4,19 +4,24 @@ import dev.plex.command.PlexCommand;
 import dev.plex.command.annotation.CommandParameters;
 import dev.plex.command.annotation.CommandPermissions;
 import dev.plex.command.source.RequiredCommandSource;
+import dev.plex.util.PlexLog;
 import dev.plex.util.PlexUtils;
 import net.kyori.adventure.text.Component;
+import org.apache.commons.lang3.text.WordUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Mob;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @CommandPermissions(permission = "plex.mobpurge", source = RequiredCommandSource.ANY)
 @CommandParameters(name = "mobpurge", description = "Purge all mobs.", usage = "/<command> <mob>", aliases = "mp")
@@ -26,27 +31,52 @@ public class MobPurgeCMD extends PlexCommand {
 
     @Override
     protected Component execute(@NotNull CommandSender sender, @Nullable Player playerSender, @NotNull String[] args) {
-        HashMap<String, Integer> entityCounts = new HashMap<>();
+        EntityType type = null;
+        String mobName = null;
+        if (args.length > 0) {
+            try {
+                type = EntityType.valueOf(args[0].toUpperCase());
+            } catch (Exception e) {
+                PlexLog.debug("A genius tried and failed removing the following invalid mob: " + args[0].toUpperCase());
+                send(sender, messageComponent("notAValidMob"));
+                return null;
+            }
+            if (!MOB_TYPES.contains(type)) {
+                PlexLog.debug(Arrays.deepToString(MOB_TYPES.toArray()));
+                PlexLog.debug("A genius tried to remove a mob that doesn't exist: " + args[0].toUpperCase());
+                sender.sendMessage(messageComponent("notAValidMobButValidEntity"));
+                return null;
+            }
+        }
+        if (type != null) {
+            mobName = WordUtils.capitalizeFully(type.name().replace("_", " "));
+            PlexLog.debug("The args aren't null so the mob is: " + mobName);
+        }
+        int count = purgeMobs(type);
+        if (type != null) {
+            PlexUtils.broadcast(messageComponent("removedEntitiesOfTypes", sender.getName(), count, mobName));
+            PlexLog.debug("All " + count + " valid mobs were removed");
+        } else {
+            PlexUtils.broadcast(messageComponent("removedMobs", sender.getName(), count));
+            PlexLog.debug("All " + count + " valid mobs were removed");
+        }
+        return null;
+    }
 
+    public int purgeMobs(EntityType type) {
+        int removed = 0;
         for (World world : Bukkit.getWorlds()) {
-            for (Entity entity : world.getEntities()) {
-                if (entity instanceof Mob) {
-                    String type = entity.getType().name();
+            for (Entity entity : world.getLivingEntities()) {
+                if (entity instanceof LivingEntity && !(entity instanceof Player)) {
+                    if (type != null && !entity.getType().equals(type)) {
+                        continue;
+                    }
                     entity.remove();
-
-                    entityCounts.put(type, entityCounts.getOrDefault(type, 0) + 1);
+                    removed++;
                 }
             }
         }
-
-        int entityCount = entityCounts.values().stream().mapToInt(a -> a).sum();
-
-        PlexUtils.broadcast(messageComponent("removedMobs", sender.getName(), entityCount));
-
-        /*entityCounts.forEach((entityName, numRemoved) -> {
-            sender.sendMessage(messageComponent("removedEntitiesOfType", sender.getName(), numRemoved, entityName));
-        });*/
-        return null;
+        return removed;
     }
 
     // Adds a tab completion for /mp so players stop complaining we (mostly me) nuked all their mobs because a filter for some reason was never added by the REAL plex devs. Go figure. -Alco_Rs11

--- a/server/src/main/java/dev/plex/command/impl/MobPurgeCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/MobPurgeCMD.java
@@ -55,13 +55,20 @@ public class MobPurgeCMD extends PlexCommand {
         int count = purgeMobs(type);
         if (type != null) {
             PlexUtils.broadcast(messageComponent("removedEntitiesOfTypes", sender.getName(), count, mobName));
-            PlexLog.debug("All " + count + " valid mobs were removed");
+            PlexLog.debug("All " + count + " of " + mobName + " were removed");
         } else {
             PlexUtils.broadcast(messageComponent("removedMobs", sender.getName(), count));
             PlexLog.debug("All " + count + " valid mobs were removed");
         }
+        sender.sendMessage(messageComponent("amountOfMobsRemoved", count, (type != null ? mobName : "mob") + multipleS(count)));
         return null;
     }
+
+    public static String multipleS(int count) {
+        return (count == 1 ? "" : "s");
+    }
+
+    // Removes the mobs.
 
     public int purgeMobs(EntityType type) {
         int removed = 0;

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -160,6 +160,9 @@ removedEntitiesOfType: "<gray>Removed {1} {2}"
 # 0 - Entity type that is invalid
 invalidEntityType: "<gray>Notice: Entity type {0} is invalid!"
 noRemovedEntities: "<gray>No entities were removed."
+noRemovedMobs: "<gray>No mobs were removed."
+notAValidMob: "<red>That is not a valid mob."
+notAValidMobButValidEntity: "<red>That is a valid entity, but is not a valid mob."
 # 0 - The command sender
 # 1 - Number of mobs removed
 removedMobs: "<red>{0} - Removed {1} mobs"

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -160,7 +160,9 @@ removedEntitiesOfType: "<gray>Removed {1} {2}"
 # 0 - Entity type that is invalid
 invalidEntityType: "<gray>Notice: Entity type {0} is invalid!"
 noRemovedEntities: "<gray>No entities were removed."
-noRemovedMobs: "<gray>No mobs were removed."
+# 0 - Number of mobs removed
+# 1 - Type of mob removed
+amountOfMobsRemoved: "<gray>{0} {1} removed."
 notAValidMob: "<red>That is not a valid mob."
 notAValidMobButValidEntity: "<red>That is a valid entity, but is not a valid mob."
 # 0 - The command sender


### PR DESCRIPTION
The ingenious plex devs somehow decided (or overlooked) the idea of /mp having a filter so instead of a filter such as "/mp pig" to remove one mob, _all_ mobs are removed no matter what. This has led to numerous complaints by players stating their shit got removed when you're intending to remove just one mob. The result: I did the job of the plex devs for them and added this essential feature to the command myself so players stop complaining I nuked their shit. 

I really don't care how shitty the command rewrite is, the bottom line is that _it works as it should_ now.