### PR TITLE
Add a toggle for restricting public chat to admins

### DIFF
--- a/server/src/main/java/dev/plex/command/impl/ToggleCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/ToggleCMD.java
@@ -55,7 +55,7 @@ public class ToggleCMD extends PlexCommand
                 }
                 case "modmode" ->
                 {
-                    PlexUtils.broadcast(messageComponent(plugin.toggles.getBoolean("moderated") ? "modmodeoff" : "modmodeon", sender.getName()));
+                    PlexUtils.broadcast(messageComponent(plugin.toggles.getBoolean("moderated") ? "modModeOff" : "modModeOn", sender.getName()));
                     return toggle("moderated");
                 }
                 default ->

--- a/server/src/main/java/dev/plex/command/impl/ToggleCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/ToggleCMD.java
@@ -32,6 +32,7 @@ public class ToggleCMD extends PlexCommand
                 sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Fluidspread" + status("fluidspread")));
                 sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Drops" + status("drops")));
                 sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Redstone" + status("redstone")));
+                sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Admin-only public chat (modmode)" + status("moderated")));
                 return null;
             }
             switch (args[0].toLowerCase())
@@ -51,6 +52,11 @@ public class ToggleCMD extends PlexCommand
                 case "redstone" ->
                 {
                     return toggle("redstone");
+                }
+                case "modmode" ->
+                {
+                    PlexUtils.broadcast(messageComponent(plugin.toggles.getBoolean("moderated") ? "modmodeoff" : "modmodeon", sender.getName()));
+                    return toggle("moderated");
                 }
                 default ->
                 {

--- a/server/src/main/java/dev/plex/listener/impl/TogglesListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/TogglesListener.java
@@ -2,14 +2,12 @@ package dev.plex.listener.impl;
 
 import dev.plex.Plex;
 import dev.plex.listener.PlexListener;
-import dev.plex.util.PlexLog;
 import dev.plex.util.PlexUtils;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockFromToEvent;
 import org.bukkit.event.block.BlockRedstoneEvent;
@@ -76,7 +74,7 @@ public class TogglesListener extends PlexListener
         Player player = event.getPlayer();
         if (plugin.toggles.getBoolean("moderated") && !Plex.get().getPermissions().has(player, "plex.togglechat.bypass"))
         {
-            event.getPlayer().sendMessage(PlexUtils.messageComponent("chatisdisabled"));
+            event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsDisabled"));
             event.setCancelled(true);
         }
     }
@@ -91,7 +89,7 @@ public class TogglesListener extends PlexListener
             message = message.replaceAll("\\s.*", "").replaceFirst("/", "");
             if (commands.contains(message.toLowerCase()))
             {
-                event.getPlayer().sendMessage(PlexUtils.messageComponent("chatisdisabled"));
+                event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsDisabled"));
                 event.setCancelled(true);
                 return;
             }
@@ -103,7 +101,7 @@ public class TogglesListener extends PlexListener
                     return;
                 }
                 if (cmd.getAliases().contains(message.toLowerCase())) {
-                    event.getPlayer().sendMessage(PlexUtils.messageComponent("chatisdisabled"));
+                    event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsDisabled"));
                     event.setCancelled(true);
                     return;
                 }

--- a/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
+++ b/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
@@ -62,7 +62,7 @@ public class ToggleMenu extends AbstractMenu
     {
         ItemStack redstone = new ItemStack(Material.REDSTONE);
         ItemMeta redstoneItemMeta = redstone.getItemMeta();
-        redstoneItemMeta.displayName(PlexUtils.mmDeserialize("<!italic><light_purple>Toggle redstone"));
+        redstoneItemMeta.displayName(PlexUtils.mmDeserialize("<!italic><light_purple>Redstone"));
         redstoneItemMeta.lore(List.of(PlexUtils.mmDeserialize("<!italic><yellow>Redstone is " + (plugin.toggles.getBoolean("redstone") ? "<green>enabled" : "<red>disabled"))));
         redstone.setItemMeta(redstoneItemMeta);
         inventory.setItem(3, redstone);

--- a/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
+++ b/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
@@ -10,7 +10,6 @@ import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class ToggleMenu extends AbstractMenu
@@ -62,7 +61,7 @@ public class ToggleMenu extends AbstractMenu
     {
         ItemStack redstone = new ItemStack(Material.REDSTONE);
         ItemMeta redstoneItemMeta = redstone.getItemMeta();
-        redstoneItemMeta.displayName(PlexUtils.mmDeserialize("<!italic><light_purple>Redstone"));
+        redstoneItemMeta.displayName(PlexUtils.mmDeserialize("<!italic><light_purple>Toggle redstone"));
         redstoneItemMeta.lore(List.of(PlexUtils.mmDeserialize("<!italic><yellow>Redstone is " + (plugin.toggles.getBoolean("redstone") ? "<green>enabled" : "<red>disabled"))));
         redstone.setItemMeta(redstoneItemMeta);
         inventory.setItem(3, redstone);
@@ -108,7 +107,7 @@ public class ToggleMenu extends AbstractMenu
         if (clicked.getType() == Material.OAK_SIGN)
         {
             plugin.toggles.set("moderated", !plugin.toggles.getBoolean("moderated"));
-            PlexUtils.broadcast(PlexUtils.messageComponent(plugin.toggles.getBoolean("moderated") ? "modmodeon" : "modmodeoff", player.getName()));
+            PlexUtils.broadcast(PlexUtils.messageComponent(plugin.toggles.getBoolean("moderated") ? "modModeOn" : "modModeOff", player.getName()));
             resetChatItem(inventory);
             player.sendMessage(PlexUtils.mmDeserialize("<gray>Toggled moderated mode."));
         }

--- a/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
+++ b/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
@@ -10,6 +10,7 @@ import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ToggleMenu extends AbstractMenu
@@ -24,6 +25,7 @@ public class ToggleMenu extends AbstractMenu
         resetFluidspreadItem(this.inventory());
         resetDropsItem(this.inventory());
         resetRedstoneItem(this.inventory());
+        resetChatItem(this.inventory());
     }
 
     private void resetExplosionItem(Inventory inventory)
@@ -60,10 +62,20 @@ public class ToggleMenu extends AbstractMenu
     {
         ItemStack redstone = new ItemStack(Material.REDSTONE);
         ItemMeta redstoneItemMeta = redstone.getItemMeta();
-        redstoneItemMeta.displayName(PlexUtils.mmDeserialize("<!italic><light_purple>Redstone"));
+        redstoneItemMeta.displayName(PlexUtils.mmDeserialize("<!italic><light_purple>Toggle redstone"));
         redstoneItemMeta.lore(List.of(PlexUtils.mmDeserialize("<!italic><yellow>Redstone is " + (plugin.toggles.getBoolean("redstone") ? "<green>enabled" : "<red>disabled"))));
         redstone.setItemMeta(redstoneItemMeta);
         inventory.setItem(3, redstone);
+    }
+
+    private void resetChatItem(Inventory inventory)
+    {
+        ItemStack chat = new ItemStack(Material.OAK_SIGN);
+        ItemMeta chatItemMeta = chat.getItemMeta();
+        chatItemMeta.displayName(PlexUtils.mmDeserialize("<!italic><light_purple>Toggle chat"));
+        chatItemMeta.lore(List.of(PlexUtils.mmDeserialize("<!italic><yellow>Public chat is currently " + (plugin.toggles.getBoolean("moderated") ? "<red>restricted to administrators" : "<green>unrestricted"))));
+        chat.setItemMeta(chatItemMeta);
+        inventory.setItem(4, chat);
     }
 
     @Override
@@ -92,6 +104,13 @@ public class ToggleMenu extends AbstractMenu
             plugin.toggles.set("redstone", !plugin.toggles.getBoolean("redstone"));
             resetRedstoneItem(inventory);
             player.sendMessage(PlexUtils.mmDeserialize("<gray>Toggled redstone."));
+        }
+        if (clicked.getType() == Material.OAK_SIGN)
+        {
+            plugin.toggles.set("moderated", !plugin.toggles.getBoolean("moderated"));
+            PlexUtils.broadcast(PlexUtils.messageComponent(plugin.toggles.getBoolean("moderated") ? "modmodeon" : "modmodeoff", player.getName()));
+            resetChatItem(inventory);
+            player.sendMessage(PlexUtils.mmDeserialize("<gray>Toggled moderated mode."));
         }
         return true;
     }

--- a/server/src/main/resources/commands.yml
+++ b/server/src/main/resources/commands.yml
@@ -61,3 +61,8 @@ block_on_mute:
   - msg
   - reply
   - mail
+
+# These commands will be blocked when chat has been toggled off, doesn't include commands that don't show a public message.
+block_on_modmode:
+  - me
+  - say

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -110,6 +110,9 @@ playerFrozen: "<red>That player is already frozen!"
 playerMuted: "<red>That player is already muted!"
 playerLockedUp: "<red>That player is already locked up!"
 muted: "<red>You are currently muted - STFU!"
+chatisdisabled: "<red>Public chat is currently restricted!"
+modmodeon: "<red>{0} - Restricting public chat to administrators"
+modmodeoff: "<aqua>{0} - Unrestricting public chat"
 # 0 - The command sender
 # 1 - The player
 kickedPlayer: "<red>{0} - Kicking {1}"

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -110,11 +110,10 @@ playerFrozen: "<red>That player is already frozen!"
 playerMuted: "<red>That player is already muted!"
 playerLockedUp: "<red>That player is already locked up!"
 muted: "<red>You are currently muted - STFU!"
-chatisdisabled: "<red>Public chat is currently restricted!"
+chatIsDisabled: "<red>Public chat is currently restricted!"
 # 0 - The command sender
-modmodeon: "<red>{0} - Restricting public chat to administrators"
-# 0 - The command sender
-modmodeoff: "<aqua>{0} - Unrestricting public chat"
+modModeOn: "<red>{0} - Restricting public chat to administrators"
+modModeOff: "<aqua>{0} - Unrestricting public chat"
 # 0 - The command sender
 # 1 - The player
 kickedPlayer: "<red>{0} - Kicking {1}"

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -111,7 +111,9 @@ playerMuted: "<red>That player is already muted!"
 playerLockedUp: "<red>That player is already locked up!"
 muted: "<red>You are currently muted - STFU!"
 chatisdisabled: "<red>Public chat is currently restricted!"
+# 0 - The command sender
 modmodeon: "<red>{0} - Restricting public chat to administrators"
+# 0 - The command sender
 modmodeoff: "<aqua>{0} - Unrestricting public chat"
 # 0 - The command sender
 # 1 - The player

--- a/server/src/main/resources/toggles.yml
+++ b/server/src/main/resources/toggles.yml
@@ -11,3 +11,6 @@ drops: true
 
 # Should redstone be enabled?
 redstone: true
+
+# Should public chat be restricted to admins only? This does not affect commands such as /w, but will affect commands such as /me.
+moderated: false


### PR DESCRIPTION
Does as it says it does. Can be bypassed by players with the plex.togglechat.bypass permission node

(it's been years since I've touched java so I may have missed something, lmk if I did and I'll fix it)