### PR TITLE
PROPERLY add a toggle option for restricting chat to administrators only

### DIFF
--- a/server/src/main/java/dev/plex/command/impl/ToggleCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/ToggleCMD.java
@@ -55,7 +55,7 @@ public class ToggleCMD extends PlexCommand
                 }
                 case "chat" ->
                 {
-                    PlexUtils.broadcast(messageComponent(plugin.toggles.getBoolean("chat") ? "chatOff" : "chatOn", sender.getName()));
+                    PlexUtils.broadcast(PlexUtils.messageComponent("chatToggled", sender.getName(), plugin.toggles.getBoolean("chat") ? "off" : "on"));
                     return toggle("chat");
                 }
                 default ->

--- a/server/src/main/java/dev/plex/command/impl/ToggleCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/ToggleCMD.java
@@ -32,7 +32,7 @@ public class ToggleCMD extends PlexCommand
                 sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Fluidspread" + status("fluidspread")));
                 sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Drops" + status("drops")));
                 sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Redstone" + status("redstone")));
-                sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Admin-only public chat (modmode)" + status("moderated")));
+                sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Chat" + status("chat")));
                 return null;
             }
             switch (args[0].toLowerCase())
@@ -53,10 +53,10 @@ public class ToggleCMD extends PlexCommand
                 {
                     return toggle("redstone");
                 }
-                case "modmode" ->
+                case "chat" ->
                 {
-                    PlexUtils.broadcast(messageComponent(plugin.toggles.getBoolean("moderated") ? "modModeOff" : "modModeOn", sender.getName()));
-                    return toggle("moderated");
+                    PlexUtils.broadcast(messageComponent(plugin.toggles.getBoolean("chat") ? "chatOff" : "chatOn", sender.getName()));
+                    return toggle("chat");
                 }
                 default ->
                 {

--- a/server/src/main/java/dev/plex/command/impl/ToggleCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/ToggleCMD.java
@@ -32,6 +32,7 @@ public class ToggleCMD extends PlexCommand
                 sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Fluidspread" + status("fluidspread")));
                 sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Drops" + status("drops")));
                 sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Redstone" + status("redstone")));
+                sender.sendMessage(PlexUtils.mmDeserialize("<gray>  - Admin-only public chat (modmode)" + status("moderated")));
                 return null;
             }
             switch (args[0].toLowerCase())
@@ -51,6 +52,11 @@ public class ToggleCMD extends PlexCommand
                 case "redstone" ->
                 {
                     return toggle("redstone");
+                }
+                case "modmode" ->
+                {
+                    PlexUtils.broadcast(messageComponent(plugin.toggles.getBoolean("moderated") ? "modModeOff" : "modModeOn", sender.getName()));
+                    return toggle("moderated");
                 }
                 default ->
                 {

--- a/server/src/main/java/dev/plex/listener/impl/TogglesListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/TogglesListener.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class TogglesListener extends PlexListener
 {
-    List<String> commands = plugin.commands.getStringList("block_on_modmode");
+    List<String> commands = plugin.commands.getStringList("block_on_mute");
     @EventHandler
     public void onExplosionPrime(ExplosionPrimeEvent event)
     {
@@ -72,9 +72,9 @@ public class TogglesListener extends PlexListener
     public void onChat(AsyncChatEvent event)
     {
         Player player = event.getPlayer();
-        if (plugin.toggles.getBoolean("moderated") && !Plex.get().getPermissions().has(player, "plex.togglechat.bypass"))
+        if (!plugin.toggles.getBoolean("chat") && !Plex.get().getPermissions().has(player, "plex.mute.bypass"))
         {
-            event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsDisabled"));
+            event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsOff"));
             event.setCancelled(true);
         }
     }
@@ -83,13 +83,13 @@ public class TogglesListener extends PlexListener
     public void onCommand(PlayerCommandPreprocessEvent event)
     {
         Player player = event.getPlayer();
-        if (plugin.toggles.getBoolean("moderated") && !Plex.get().getPermissions().has(player, "plex.togglechat.bypass"))
+        if (!plugin.toggles.getBoolean("chat") && !Plex.get().getPermissions().has(player, "plex.mute.bypass"))
         {
             String message = event.getMessage();
             message = message.replaceAll("\\s.*", "").replaceFirst("/", "");
             if (commands.contains(message.toLowerCase()))
             {
-                event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsDisabled"));
+                event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsOff"));
                 event.setCancelled(true);
                 return;
             }
@@ -101,7 +101,7 @@ public class TogglesListener extends PlexListener
                     return;
                 }
                 if (cmd.getAliases().contains(message.toLowerCase())) {
-                    event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsDisabled"));
+                    event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsOff"));
                     event.setCancelled(true);
                     return;
                 }

--- a/server/src/main/java/dev/plex/listener/impl/TogglesListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/TogglesListener.java
@@ -1,6 +1,12 @@
 package dev.plex.listener.impl;
 
+import dev.plex.Plex;
 import dev.plex.listener.PlexListener;
+import dev.plex.util.PlexUtils;
+import io.papermc.paper.event.player.AsyncChatEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.block.BlockFromToEvent;
@@ -8,9 +14,13 @@ import org.bukkit.event.block.BlockRedstoneEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.ExplosionPrimeEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+import java.util.List;
 
 public class TogglesListener extends PlexListener
 {
+    List<String> commands = plugin.commands.getStringList("block_on_modmode");
     @EventHandler
     public void onExplosionPrime(ExplosionPrimeEvent event)
     {
@@ -56,6 +66,48 @@ public class TogglesListener extends PlexListener
         {
             event.setCancelled(true);
         }
+    }
+
+    @EventHandler
+    public void onChat(AsyncChatEvent event)
+    {
+        Player player = event.getPlayer();
+        if (plugin.toggles.getBoolean("moderated") && !Plex.get().getPermissions().has(player, "plex.togglechat.bypass"))
+        {
+            event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsDisabled"));
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onCommand(PlayerCommandPreprocessEvent event)
+    {
+        Player player = event.getPlayer();
+        if (plugin.toggles.getBoolean("moderated") && !Plex.get().getPermissions().has(player, "plex.togglechat.bypass"))
+        {
+            String message = event.getMessage();
+            message = message.replaceAll("\\s.*", "").replaceFirst("/", "");
+            if (commands.contains(message.toLowerCase()))
+            {
+                event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsDisabled"));
+                event.setCancelled(true);
+                return;
+            }
+
+            for (String command : commands)
+            {
+                Command cmd = Bukkit.getCommandMap().getCommand(command);
+                if (cmd == null) {
+                    return;
+                }
+                if (cmd.getAliases().contains(message.toLowerCase())) {
+                    event.getPlayer().sendMessage(PlexUtils.messageComponent("chatIsDisabled"));
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+        }
+
     }
 
     /* I have no idea if this is the best way to do this

--- a/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
+++ b/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
@@ -72,7 +72,7 @@ public class ToggleMenu extends AbstractMenu
         ItemStack chat = new ItemStack(Material.OAK_SIGN);
         ItemMeta chatItemMeta = chat.getItemMeta();
         chatItemMeta.displayName(PlexUtils.mmDeserialize("<!italic><light_purple>Toggle chat"));
-        chatItemMeta.lore(List.of(PlexUtils.mmDeserialize("<!italic><yellow>Public chat is currently " + (plugin.toggles.getBoolean("moderated") ? "<red>restricted to administrators" : "<green>unrestricted"))));
+        chatItemMeta.lore(List.of(PlexUtils.mmDeserialize("<!italic><yellow>Chat is currently " + (plugin.toggles.getBoolean("chat") ? "<green>on" : "<red>off"))));
         chat.setItemMeta(chatItemMeta);
         inventory.setItem(4, chat);
     }
@@ -106,10 +106,10 @@ public class ToggleMenu extends AbstractMenu
         }
         if (clicked.getType() == Material.OAK_SIGN)
         {
-            plugin.toggles.set("moderated", !plugin.toggles.getBoolean("moderated"));
-            PlexUtils.broadcast(PlexUtils.messageComponent(plugin.toggles.getBoolean("moderated") ? "modModeOn" : "modModeOff", player.getName()));
+            plugin.toggles.set("chat", !plugin.toggles.getBoolean("chat"));
+            PlexUtils.broadcast(PlexUtils.messageComponent(plugin.toggles.getBoolean("chat") ? "chatOn" : "chatOff", player.getName()));
             resetChatItem(inventory);
-            player.sendMessage(PlexUtils.mmDeserialize("<gray>Toggled moderated mode."));
+            player.sendMessage(PlexUtils.mmDeserialize("<gray>Toggled chat."));
         }
         return true;
     }

--- a/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
+++ b/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
@@ -107,7 +107,7 @@ public class ToggleMenu extends AbstractMenu
         if (clicked.getType() == Material.OAK_SIGN)
         {
             plugin.toggles.set("chat", !plugin.toggles.getBoolean("chat"));
-            PlexUtils.broadcast(PlexUtils.messageComponent(plugin.toggles.getBoolean("chat") ? "chatOn" : "chatOff", player.getName()));
+            PlexUtils.broadcast(PlexUtils.messageComponent("chatToggled", player.getName(), plugin.toggles.getBoolean("chat") ? "on" : "off"));
             resetChatItem(inventory);
             player.sendMessage(PlexUtils.mmDeserialize("<gray>Toggled chat."));
         }

--- a/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
+++ b/server/src/main/java/dev/plex/menu/impl/ToggleMenu.java
@@ -24,6 +24,7 @@ public class ToggleMenu extends AbstractMenu
         resetFluidspreadItem(this.inventory());
         resetDropsItem(this.inventory());
         resetRedstoneItem(this.inventory());
+        resetChatItem(this.inventory());
     }
 
     private void resetExplosionItem(Inventory inventory)
@@ -66,6 +67,16 @@ public class ToggleMenu extends AbstractMenu
         inventory.setItem(3, redstone);
     }
 
+    private void resetChatItem(Inventory inventory)
+    {
+        ItemStack chat = new ItemStack(Material.OAK_SIGN);
+        ItemMeta chatItemMeta = chat.getItemMeta();
+        chatItemMeta.displayName(PlexUtils.mmDeserialize("<!italic><light_purple>Toggle chat"));
+        chatItemMeta.lore(List.of(PlexUtils.mmDeserialize("<!italic><yellow>Public chat is currently " + (plugin.toggles.getBoolean("moderated") ? "<red>restricted to administrators" : "<green>unrestricted"))));
+        chat.setItemMeta(chatItemMeta);
+        inventory.setItem(4, chat);
+    }
+
     @Override
     public boolean onClick(InventoryView view, Inventory inventory, Player player, ItemStack clicked)
     {
@@ -92,6 +103,13 @@ public class ToggleMenu extends AbstractMenu
             plugin.toggles.set("redstone", !plugin.toggles.getBoolean("redstone"));
             resetRedstoneItem(inventory);
             player.sendMessage(PlexUtils.mmDeserialize("<gray>Toggled redstone."));
+        }
+        if (clicked.getType() == Material.OAK_SIGN)
+        {
+            plugin.toggles.set("moderated", !plugin.toggles.getBoolean("moderated"));
+            PlexUtils.broadcast(PlexUtils.messageComponent(plugin.toggles.getBoolean("moderated") ? "modModeOn" : "modModeOff", player.getName()));
+            resetChatItem(inventory);
+            player.sendMessage(PlexUtils.mmDeserialize("<gray>Toggled moderated mode."));
         }
         return true;
     }

--- a/server/src/main/resources/commands.yml
+++ b/server/src/main/resources/commands.yml
@@ -61,3 +61,8 @@ block_on_mute:
   - msg
   - reply
   - mail
+
+# These commands will be blocked when chat has been toggled off, doesn't include commands that don't show a public message.
+block_on_modmode:
+  - me
+  - say

--- a/server/src/main/resources/commands.yml
+++ b/server/src/main/resources/commands.yml
@@ -54,15 +54,10 @@ commands:
   - "r:a:^(co|core|coreprotect) (rb|rollback|l|lookup|rl|reload):_"
   - "r:e:^[A-z]*:[A-z]*::<gray>Plugin specific commands are disabled."
 
-# These commands will be blocked when a player is muted
+# These commands will be blocked when a player is muted or when chat is toggled off.
 block_on_mute:
   - me
   - say
   - msg
   - reply
   - mail
-
-# These commands will be blocked when chat has been toggled off, doesn't include commands that don't show a public message.
-block_on_modmode:
-  - me
-  - say

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -110,6 +110,10 @@ playerFrozen: "<red>That player is already frozen!"
 playerMuted: "<red>That player is already muted!"
 playerLockedUp: "<red>That player is already locked up!"
 muted: "<red>You are currently muted - STFU!"
+chatIsDisabled: "<red>Public chat is currently restricted!"
+# 0 - The command sender
+modModeOn: "<red>{0} - Restricting public chat to administrators"
+modModeOff: "<aqua>{0} - Unrestricting public chat"
 # 0 - The command sender
 # 1 - The player
 kickedPlayer: "<red>{0} - Kicking {1}"

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -110,10 +110,11 @@ playerFrozen: "<red>That player is already frozen!"
 playerMuted: "<red>That player is already muted!"
 playerLockedUp: "<red>That player is already locked up!"
 muted: "<red>You are currently muted - STFU!"
-chatIsDisabled: "<red>Public chat is currently restricted!"
+chatIsOff: "<red>Chat is currently toggled off!"
 # 0 - The command sender
-modModeOn: "<red>{0} - Restricting public chat to administrators"
-modModeOff: "<aqua>{0} - Unrestricting public chat"
+chatOff: "<red>{0} - Toggled chat off"
+# 0 - The command sender
+chatOn: "<aqua>{0} - Toggled chat on"
 # 0 - The command sender
 # 1 - The player
 kickedPlayer: "<red>{0} - Kicking {1}"

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -112,9 +112,8 @@ playerLockedUp: "<red>That player is already locked up!"
 muted: "<red>You are currently muted - STFU!"
 chatIsOff: "<red>Chat is currently toggled off!"
 # 0 - The command sender
-chatOff: "<red>{0} - Toggled chat off"
-# 0 - The command sender
-chatOn: "<aqua>{0} - Toggled chat on"
+# 1 - The set value of the chat toggle
+chatToggled: "<red>{0} - Toggled chat {1}"
 # 0 - The command sender
 # 1 - The player
 kickedPlayer: "<red>{0} - Kicking {1}"

--- a/server/src/main/resources/toggles.yml
+++ b/server/src/main/resources/toggles.yml
@@ -12,5 +12,5 @@ drops: true
 # Should redstone be enabled?
 redstone: true
 
-# Should public chat be restricted to admins only? This does not affect commands such as /w, but will affect commands such as /me.
-moderated: false
+# Is chat enabled?
+chat: true

--- a/server/src/main/resources/toggles.yml
+++ b/server/src/main/resources/toggles.yml
@@ -11,3 +11,6 @@ drops: true
 
 # Should redstone be enabled?
 redstone: true
+
+# Should public chat be restricted to admins only? This does not affect commands such as /w, but will affect commands such as /me.
+moderated: false


### PR DESCRIPTION
Can be used via the toggle gui or via /toggle modmode. The permision node plex.togglechat.bypass allows admins / other players to bypass this toggle.