### PR TITLE
Move most hard coded messages to messages.yml to allow customization.

### DIFF
--- a/server/src/main/java/dev/plex/command/impl/BanCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/BanCMD.java
@@ -13,17 +13,7 @@ import dev.plex.util.BungeeUtil;
 import dev.plex.util.PlexLog;
 import dev.plex.util.PlexUtils;
 import dev.plex.util.TimeUtils;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import net.kyori.adventure.text.Component;
-import network.darkhelmet.prism.api.PrismParameters;
-import network.darkhelmet.prism.api.Result;
-import network.darkhelmet.prism.api.actions.PrismProcessType;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -31,7 +21,12 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@CommandParameters(name = "ban", usage = "/<command> <player> [reason] [-nrb]", aliases = "offlineban,gtfo", description = "Bans a player, offline or online")
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+
+@CommandParameters(name = "ban", usage = "/<command> <player> [reason] [-rb]", aliases = "offlineban,gtfo", description = "Bans a player, offline or online")
 @CommandPermissions(permission = "plex.ban", source = RequiredCommandSource.ANY)
 
 public class BanCMD extends PlexCommand
@@ -63,13 +58,13 @@ public class BanCMD extends PlexCommand
             String reason;
             Punishment punishment = new Punishment(plexPlayer.getUuid(), getUUID(sender));
             punishment.setType(PunishmentType.BAN);
-            boolean rollBack = true;
+            boolean rollBack = false;
             if (args.length > 1)
             {
                 reason = StringUtils.join(args, " ", 1, args.length);
                 String newReason = StringUtils.normalizeSpace(reason.replace("-nrb", ""));
                 punishment.setReason(newReason.trim().isEmpty() ? messageString("noReasonProvided") : newReason);
-                rollBack = !reason.startsWith("-nrb") && !reason.endsWith("-nrb");
+                rollBack = reason.startsWith("-rb") || reason.endsWith("-rb");
             }
             else
             {
@@ -94,7 +89,7 @@ public class BanCMD extends PlexCommand
 
             if (rollBack)
             {
-                if (plugin.getPrismHook() != null && plugin.getPrismHook().hasPrism())
+                /*if (plugin.getPrismHook() != null && plugin.getPrismHook().hasPrism())
                 {
                     PrismParameters parameters = plugin.getPrismHook().prismApi().createParameters();
                     parameters.addActionType("block-place");
@@ -119,10 +114,10 @@ public class BanCMD extends PlexCommand
                         }
                     });
                 }
-                else if (plugin.getCoreProtectHook() != null && plugin.getCoreProtectHook().hasCoreProtect())
+                else */
+                if (plugin.getCoreProtectHook() != null && plugin.getCoreProtectHook().hasCoreProtect())
                 {
-                    PlexLog.debug("Testing coreprotect");
-                    Bukkit.getGlobalRegionScheduler().run(plugin, scheduledTask ->
+                    Bukkit.getAsyncScheduler().runNow(plugin, scheduledTask ->
                     {
                         plugin.getCoreProtectHook().coreProtectAPI().performRollback(86400, Collections.singletonList(plexPlayer.getName()), null, null, null, null, 0, null);
                     });

--- a/server/src/main/java/dev/plex/command/impl/BanCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/BanCMD.java
@@ -68,12 +68,12 @@ public class BanCMD extends PlexCommand
             {
                 reason = StringUtils.join(args, " ", 1, args.length);
                 String newReason = StringUtils.normalizeSpace(reason.replace("-nrb", ""));
-                punishment.setReason(newReason.trim().isEmpty() ? "No reason provided." : newReason);
+                punishment.setReason(newReason.trim().isEmpty() ? messageString("noReasonProvided") : newReason);
                 rollBack = !reason.startsWith("-nrb") && !reason.endsWith("-nrb");
             }
             else
             {
-                punishment.setReason("No reason provided.");
+                punishment.setReason(messageString("noReasonProvided"));
             }
             punishment.setPunishedUsername(plexPlayer.getName());
             ZonedDateTime date = ZonedDateTime.now(ZoneId.of(TimeUtils.TIMEZONE));

--- a/server/src/main/java/dev/plex/command/impl/BanCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/BanCMD.java
@@ -135,9 +135,9 @@ public class BanCMD extends PlexCommand
         {
             return PlexUtils.getPlayerNameList();
         }
-        if (args.length != 1 && silentCheckPermission(sender, this.getPermission()))
+        if (args.length > 1 && silentCheckPermission(sender, this.getPermission()))
         {
-            return Collections.singletonList("-nrb");
+            return Collections.singletonList("-rb");
         }
         return Collections.emptyList();
     }

--- a/server/src/main/java/dev/plex/command/impl/BcastLoginMessageCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/BcastLoginMessageCMD.java
@@ -41,7 +41,7 @@ public class BcastLoginMessageCMD extends PlexCommand
         if (!loginMessage.isEmpty())
         {
             PlexUtils.broadcast(PlexUtils.stringToComponent(loginMessage));
-            PlexUtils.broadcast(mmString("<yellow>" + plexPlayer.getName() + " joined the game"));
+            PlexUtils.broadcast(messageComponent("loginMessage", plexPlayer.getName()));
         }
         else
         {

--- a/server/src/main/java/dev/plex/command/impl/DebugCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/DebugCMD.java
@@ -41,9 +41,9 @@ public class DebugCMD extends PlexCommand
                 if (plugin.getRedisConnection().getJedis().exists(player.getUniqueId().toString()))
                 {
                     plugin.getRedisConnection().getJedis().del(player.getUniqueId().toString());
-                    return componentFromString("Successfully reset " + player.getName() + "'s Redis punishments!").color(NamedTextColor.YELLOW);
+                    return messageComponent("redisResetSuccessful", player.getName());
                 }
-                return componentFromString("Couldn't find player in Redis punishments.");
+                return messageComponent("redisResetPlayerNotFound");
             }
         }
         if (args[0].equalsIgnoreCase("gamerules"))
@@ -62,7 +62,7 @@ public class DebugCMD extends PlexCommand
                     PlexLog.log("Set specific gamerules for world: " + world.toLowerCase(Locale.ROOT));
                 }
             }
-            return mmString("<aqua>Re-applied game all the game rules!");
+            return messageComponent("reappliedGamerules");
         }
         if (args[0].equalsIgnoreCase("aliases"))
         {
@@ -72,9 +72,9 @@ public class DebugCMD extends PlexCommand
                 Command command = plugin.getServer().getCommandMap().getCommand(commandName);
                 if (command == null)
                 {
-                    return mmString("<red>That command could not be found!");
+                    return messageComponent("commandNotFound");
                 }
-                return mmString("<aqua>Aliases for " + commandName + " are: " + Arrays.toString(command.getAliases().toArray(new String[0])));
+                return messageComponent("commandAliases", commandName, Arrays.toString(command.getAliases().toArray(new String[0])));
             }
         }
         if (args[0].equalsIgnoreCase("pagination"))

--- a/server/src/main/java/dev/plex/command/impl/EntityWipeCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/EntityWipeCMD.java
@@ -134,7 +134,7 @@ public class EntityWipeCMD extends PlexCommand
         }
         catch (NumberFormatException ex)
         {
-            sender.sendMessage(mmString("<red>" + string + "<red> is not a valid number!"));
+            sender.sendMessage(messageComponent("notANumber", string));
         }
         return null;
     }

--- a/server/src/main/java/dev/plex/command/impl/KickCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/KickCMD.java
@@ -38,7 +38,7 @@ public class KickCMD extends PlexCommand
         }
 
         PlexPlayer plexPlayer = DataUtils.getPlayer(args[0]);
-        String reason = "No reason provided";
+        String reason = messageString("noReasonProvided");
 
         if (plexPlayer == null)
         {

--- a/server/src/main/java/dev/plex/command/impl/ListCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/ListCMD.java
@@ -2,6 +2,7 @@ package dev.plex.command.impl;
 
 import com.google.common.collect.Lists;
 import dev.plex.command.PlexCommand;
+import dev.plex.util.PlexUtils;
 import dev.plex.command.annotation.CommandParameters;
 import dev.plex.command.annotation.CommandPermissions;
 import dev.plex.hook.VaultHook;
@@ -27,17 +28,7 @@ public class ListCMD extends PlexCommand
         List<Player> players = Lists.newArrayList(Bukkit.getOnlinePlayers());
         players.removeIf(PlayerMeta::isVanished);
         Component list = Component.empty();
-        Component header = Component.text("There " + (players.size() == 1 ? "is" : "are") + " currently").color(NamedTextColor.GRAY)
-                .append(Component.space())
-                .append(Component.text(players.size()).color(NamedTextColor.YELLOW))
-                .append(Component.space())
-                .append(Component.text(players.size() == 1 ? "player" : "players").color(NamedTextColor.GRAY))
-                .append(Component.space())
-                .append(Component.text("online out of").color(NamedTextColor.GRAY))
-                .append(Component.space())
-                .append(Component.text(Bukkit.getMaxPlayers()).color(NamedTextColor.YELLOW))
-                .append(Component.space())
-                .append(Component.text(Bukkit.getMaxPlayers() == 1 ? "player." : "players.").color(NamedTextColor.GRAY));
+        Component header = PlexUtils.messageComponent(players.size() == 1 ? "listHeader" : "listHeaderPlural", players.size(), Bukkit.getMaxPlayers());
         send(sender, header);
         if (players.isEmpty())
         {

--- a/server/src/main/java/dev/plex/command/impl/NotesCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/NotesCMD.java
@@ -124,11 +124,11 @@ public class NotesCMD extends PlexCommand
 
     private void readNotes(@NotNull CommandSender sender, PlexPlayer plexPlayer, List<Note> notes)
     {
-        AtomicReference<Component> noteList = new AtomicReference<>(Component.text("Player notes for: " + plexPlayer.getName()).color(NamedTextColor.GREEN));
+        AtomicReference<Component> noteList = new AtomicReference<>(messageComponent("notesHeader", plexPlayer.getName()));
         for (Note note : notes)
         {
-            Component noteLine = mmString("<gold><!italic>" + note.getId() + " - Written by: " + DataUtils.getPlayer(note.getWrittenBy()).getName() + " on " + TimeUtils.useTimezone(note.getTimestamp()));
-            noteLine = noteLine.append(mmString("<newline><yellow># " + note.getNote()));
+            Component noteLine = messageComponent("notePrefix", note.getId(), DataUtils.getPlayer(note.getWrittenBy()).getName(), TimeUtils.useTimezone(note.getTimestamp()));
+            noteLine = noteLine.append(messageComponent("noteLine", note.getNote()));
             noteList.set(noteList.get().append(Component.newline()));
             noteList.set(noteList.get().append(noteLine));
         }

--- a/server/src/main/java/dev/plex/command/impl/SmiteCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/SmiteCMD.java
@@ -78,21 +78,16 @@ public class SmiteCMD extends PlexCommand
         final Player player = getNonNullPlayer(args[0]);
         final PlexPlayer plexPlayer = getPlexPlayer(player);
 
-        Title title = Title.title(Component.text("You've been smitten.").color(NamedTextColor.RED), Component.text("Be sure to follow the rules!").color(NamedTextColor.YELLOW));
+        Title title = Title.title(messageComponent("smiteTitleHeader"), messageComponent("smiteTitleMessage", reason, sender.getName()));
         player.showTitle(title);
 
         if (!silent)
         {
-            PlexUtils.broadcast(mmString("<red>" + player.getName() + " has been a naughty, naughty boy."));
-            if (reason != null)
-            {
-                PlexUtils.broadcast(mmString("  <red>Reason: " + "<yellow>" + reason));
-            }
-            PlexUtils.broadcast(mmString("  <red>Smitten by: " + "<yellow>" + sender.getName()));
+            PlexUtils.broadcast(messageComponent("smiteBroadcast", player.getName(), reason != null ? reason : messageString("noReasonProvided"), sender.getName()));
         }
         else
         {
-            send(sender, "Smitten " + player.getName() + " quietly.");
+            send(sender, messageComponent("smittenQuietly", player.getName()));
         }
 
         // Set gamemode to survival
@@ -129,8 +124,8 @@ public class SmiteCMD extends PlexCommand
         if (reason != null)
         {
             punishment.setReason(reason);
-            send(player, mmString("<red>You've been smitten. Reason: <yellow>" + reason));
         }
+        send(player, messageComponent("smitten", reason != null ? reason : messageString("noReasonProvided")));
         return null;
     }
 

--- a/server/src/main/java/dev/plex/command/impl/TempbanCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/TempbanCMD.java
@@ -58,12 +58,12 @@ public class TempbanCMD extends PlexCommand
         {
             reason = StringUtils.join(args, " ", 2, args.length);
             String newReason = StringUtils.normalizeSpace(reason.replace("-nrb", ""));
-            punishment.setReason(newReason.trim().isEmpty() ? "No reason provided." : newReason);
+            punishment.setReason(newReason.trim().isEmpty() ? messageString("noReasonProvided") : newReason);
             rollBack = !reason.startsWith("-nrb") && !reason.endsWith("-nrb");
         }
         else
         {
-            punishment.setReason("No reason provided.");
+            punishment.setReason(messageString("noReasonProvided"));
         }
         punishment.setPunishedUsername(target.getName());
         punishment.setEndDate(TimeUtils.createDate(args[1]));

--- a/server/src/main/java/dev/plex/command/impl/TempbanCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/TempbanCMD.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 
-@CommandParameters(name = "tempban", usage = "/<command> <player> <time> [reason]", description = "Temporarily ban a player")
+@CommandParameters(name = "tempban", usage = "/<command> <player> <time> [reason] [-rb]", description = "Temporarily ban a player")
 @CommandPermissions(permission = "plex.tempban", source = RequiredCommandSource.ANY)
 
 public class TempbanCMD extends PlexCommand
@@ -53,13 +53,13 @@ public class TempbanCMD extends PlexCommand
         }
         Punishment punishment = new Punishment(target.getUuid(), getUUID(sender));
         punishment.setType(PunishmentType.TEMPBAN);
-        boolean rollBack = true;
+        boolean rollBack = false;
         if (args.length > 2)
         {
             reason = StringUtils.join(args, " ", 2, args.length);
             String newReason = StringUtils.normalizeSpace(reason.replace("-nrb", ""));
             punishment.setReason(newReason.trim().isEmpty() ? messageString("noReasonProvided") : newReason);
-            rollBack = !reason.startsWith("-nrb") && !reason.endsWith("-nrb");
+            rollBack = reason.startsWith("-rb") || reason.endsWith("-rb");
         }
         else
         {

--- a/server/src/main/java/dev/plex/listener/impl/AntiNukerListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/AntiNukerListener.java
@@ -1,6 +1,7 @@
 package dev.plex.listener.impl;
 
 import dev.plex.listener.PlexListener;
+import dev.plex.util.PlexUtils;
 import dev.plex.services.impl.TimingService;
 import net.kyori.adventure.text.Component;
 import org.bukkit.event.EventHandler;
@@ -19,7 +20,7 @@ public class AntiNukerListener extends PlexListener
         if (getCount(event.getPlayer().getUniqueId()) > 200L)
         {
             TimingService.strikes.merge(event.getPlayer().getUniqueId(), 1L, Long::sum);
-            event.getPlayer().kick(Component.text("Please turn off your nuker!"));
+            event.getPlayer().kick(PlexUtils.messageComponent("nukerKickMessage"));
             event.setCancelled(true);
         }
     }
@@ -31,7 +32,7 @@ public class AntiNukerListener extends PlexListener
         if (getCount(event.getPlayer().getUniqueId()) > 200L)
         {
             TimingService.strikes.merge(event.getPlayer().getUniqueId(), 1L, Long::sum);
-            event.getPlayer().kick(Component.text("Please turn off your nuker!"));
+            event.getPlayer().kick(PlexUtils.messageComponent("nukerKickMessage"));
             event.setCancelled(true);
         }
     }

--- a/server/src/main/java/dev/plex/listener/impl/AntiSpamListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/AntiSpamListener.java
@@ -1,6 +1,7 @@
 package dev.plex.listener.impl;
 
 import dev.plex.listener.PlexListener;
+import dev.plex.util.PlexUtils;
 import dev.plex.services.impl.TimingService;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
@@ -19,7 +20,7 @@ public class AntiSpamListener extends PlexListener
         TimingService.spamCooldown.merge(event.getPlayer().getUniqueId(), 1L, Long::sum);
         if (getCount(event.getPlayer().getUniqueId()) > 8L)
         {
-            event.getPlayer().sendMessage(Component.text("Please refrain from spamming messages.").color(NamedTextColor.GRAY));
+            event.getPlayer().sendMessage(PlexUtils.messageComponent("antiSpamMessage"));
             event.setCancelled(true);
         }
     }
@@ -30,7 +31,7 @@ public class AntiSpamListener extends PlexListener
         TimingService.spamCooldown.merge(event.getPlayer().getUniqueId(), 1L, Long::sum);
         if (getCount(event.getPlayer().getUniqueId()) > 8L)
         {
-            event.getPlayer().sendMessage(Component.text("Please refrain from spamming commands.").color(NamedTextColor.GRAY));
+            event.getPlayer().sendMessage(PlexUtils.messageComponent("antiSpamMessage"));
             event.setCancelled(true);
         }
     }

--- a/server/src/main/java/dev/plex/listener/impl/PlayerListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/PlayerListener.java
@@ -71,11 +71,9 @@ public class PlayerListener extends PlexListener
 
         plugin.getSqlNotes().getNotes(plexPlayer.getUuid()).whenComplete((notes, ex) ->
         {
-            String plural = notes.size() == 1 ? "note." : "notes.";
             if (!notes.isEmpty())
             {
-                PlexUtils.broadcastToAdmins(Component.text(plexPlayer.getName() + " has " + notes.size() + " " + plural).color(NamedTextColor.GOLD), "plex.notes.notify");
-                PlexUtils.broadcastToAdmins(Component.text("Click to view their " + plural).clickEvent(ClickEvent.runCommand("/notes " + plexPlayer.getName() + " list")).color(NamedTextColor.GOLD), "plex.notes.notify");
+                PlexUtils.broadcastToAdmins(PlexUtils.messageComponent(notes.size() == 1 ? "playerNoteAlert" : "playerNoteAlertPlural", plexPlayer.getName(), notes.size()), "plex.notes.notify");
             }
         });
     }

--- a/server/src/main/java/dev/plex/listener/impl/ServerListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/ServerListener.java
@@ -1,47 +1,187 @@
 package dev.plex.listener.impl;
 
-import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import dev.plex.listener.PlexListener;
-import dev.plex.util.PlexUtils;
-import dev.plex.util.RandomUtil;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.block.data.Openable;
+import org.bukkit.command.Command;
+import org.bukkit.command.PluginIdentifiableCommand;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntitySpawnEvent;
+import org.bukkit.event.player.*;
 
+import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
-public class ServerListener extends PlexListener
+public class WorldListener extends PlexListener
 {
-    @EventHandler
-    public void onServerPing(PaperServerListPingEvent event)
+    private final List<String> EDIT_COMMANDS = Arrays.asList("bigtree", "ebigtree", "largetree", "elargetree", "break", "ebreak", "antioch", "nuke", "editsign", "tree", "etree");
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onBlockPlace(BlockPlaceEvent event)
     {
-        String baseMotd = plugin.config.getString("server.motd");
-        baseMotd = baseMotd.replace("\\n", "\n");
-        baseMotd = baseMotd.replace("%servername%", plugin.config.getString("server.name"));
-        baseMotd = baseMotd.replace("%mcversion%", Bukkit.getBukkitVersion().split("-")[0]);
-        if (plugin.config.getBoolean("server.colorize_motd"))
+        if (!canModifyWorld(event.getPlayer(), true))
         {
-            AtomicReference<Component> motd = new AtomicReference<>(Component.empty());
-            for (final String word : baseMotd.split(" "))
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onBlockBreak(BlockBreakEvent event)
+    {
+        if (!canModifyWorld(event.getPlayer(), true))
+        {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onInteractWorld(PlayerInteractEvent event)
+    {
+        if (event.getInteractionPoint() != null && event.getInteractionPoint().getBlock().getBlockData() instanceof Openable) return;
+        if (!canModifyWorld(event.getPlayer(), true))
+        {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onInteractWorld(PlayerInteractEntityEvent event)
+    {
+        if (!canModifyWorld(event.getPlayer(), true))
+        {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onInteractWorld(PlayerItemDamageEvent event)
+    {
+        if (!canModifyWorld(event.getPlayer(), true))
+        {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onInteractWorld(EntityDamageByEntityEvent event)
+    {
+        if (!(event.getDamager() instanceof Player player)) return;
+        if (!canModifyWorld(player, true))
+        {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onEntitySpawn(EntitySpawnEvent event)
+    {
+        if (event.getEntityType() != EntityType.SLIME)
+        {
+            return;
+        }
+        event.setCancelled(true);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event)
+    {
+        // If the person has permission to modify the world, we don't need to block WorldEdit
+        if (canModifyWorld(event.getPlayer(), false))
+        {
+            return;
+        }
+
+        String message = event.getMessage();
+        // Don't check the arguments
+        message = message.replaceAll("\\s.*", "").replaceFirst("/", "");
+        Command command = Bukkit.getCommandMap().getCommand(message);
+        if (command != null)
+        {
+            // This does check for aliases
+            boolean isWeCommand = command instanceof PluginIdentifiableCommand && ((PluginIdentifiableCommand) command).getPlugin().equals(Bukkit.getPluginManager().getPlugin("WorldEdit"));
+            boolean isFaweCommand = command instanceof PluginIdentifiableCommand && ((PluginIdentifiableCommand) command).getPlugin().equals(Bukkit.getPluginManager().getPlugin("FastAsyncWorldEdit"));
+            if (isWeCommand || isFaweCommand || EDIT_COMMANDS.contains(message.toLowerCase()))
             {
-                motd.set(motd.get().append(Component.text(word).color(RandomUtil.getRandomColor())));
-                motd.set(motd.get().append(Component.space()));
+                String noEdit = plugin.config.getString("worlds." + world.getName().toLowerCase() + ".modification.message");
+                event.getPlayer().sendMessage(MiniMessage.miniMessage().deserialize(noEdit));
+                event.setCancelled(true);
             }
-            event.motd(motd.get());
         }
-        else
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onWorldTeleport(PlayerTeleportEvent event)
+    {
+        if (!canEnterWorld(event.getPlayer(), event.getTo().getWorld()))
         {
-            event.motd(PlexUtils.mmDeserialize(baseMotd.trim()));
+            event.setCancelled(true);
         }
-        if (plugin.config.contains("server.sample"))
+    }
+
+    /**
+     * Check if a Player has the ability to modify the world they are in
+     *
+     * @param player      The player who wants to modify the world
+     * @param showMessage Whether the message from the config.yml should be shown
+     * @return Returns true if the person has the ability to modify the world
+     */
+    private boolean canModifyWorld(Player player, boolean showMessage)
+    {
+        World world = player.getWorld();
+        String permission = plugin.config.getString("worlds." + world.getName().toLowerCase() + ".modification.permission");
+        if (permission == null)
         {
-            List<String> samples = plugin.config.getStringList("server.sample");
-            if (!samples.isEmpty())
+            return true;
+        }
+        if (player.hasPermission(permission))
+        {
+            return true;
+        }
+
+        if (showMessage)
+        {
+            String noEdit = plugin.config.getString("worlds." + world.getName().toLowerCase() + ".modification.message");
+            if (noEdit != null)
             {
-                event.getPlayerSample().clear();
-                event.getPlayerSample().addAll(samples.stream().map(string -> string.replace("&", "§")).map(Bukkit::createProfile).toList());
+                player.sendMessage(MiniMessage.miniMessage().deserialize(noEdit));
             }
         }
+        return false;
+    }
+
+    /**
+     * Check if a Player has the ability to enter the requested world
+     *
+     * @param player The player who wants to enter the world
+     * @return Returns true if the person has the ability to enter the world
+     */
+    private boolean canEnterWorld(Player player, World destination)
+    {
+        String permission = plugin.config.getString("worlds." + destination.getName().toLowerCase() + ".entry.permission");
+        if (permission == null)
+        {
+            return true;
+        }
+        if (player.hasPermission(permission))
+        {
+            return true;
+        }
+
+        String noEntry = plugin.config.getString("worlds." + destination.getName().toLowerCase() + ".entry.message");
+        if (noEntry != null)
+        {
+            player.sendMessage(MiniMessage.miniMessage().deserialize(noEntry));
+        }
+        return false;
     }
 }

--- a/server/src/main/java/dev/plex/listener/impl/ServerListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/ServerListener.java
@@ -1,187 +1,47 @@
 package dev.plex.listener.impl;
 
+import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import dev.plex.listener.PlexListener;
+import dev.plex.util.PlexUtils;
+import dev.plex.util.RandomUtil;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
-import org.bukkit.World;
-import org.bukkit.block.data.Openable;
-import org.bukkit.command.Command;
-import org.bukkit.command.PluginIdentifiableCommand;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntitySpawnEvent;
-import org.bukkit.event.player.*;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
-public class WorldListener extends PlexListener
+public class ServerListener extends PlexListener
 {
-    private final List<String> EDIT_COMMANDS = Arrays.asList("bigtree", "ebigtree", "largetree", "elargetree", "break", "ebreak", "antioch", "nuke", "editsign", "tree", "etree");
-
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onBlockPlace(BlockPlaceEvent event)
+    @EventHandler
+    public void onServerPing(PaperServerListPingEvent event)
     {
-        if (!canModifyWorld(event.getPlayer(), true))
+        String baseMotd = plugin.config.getString("server.motd");
+        baseMotd = baseMotd.replace("\\n", "\n");
+        baseMotd = baseMotd.replace("%servername%", plugin.config.getString("server.name"));
+        baseMotd = baseMotd.replace("%mcversion%", Bukkit.getBukkitVersion().split("-")[0]);
+        if (plugin.config.getBoolean("server.colorize_motd"))
         {
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onBlockBreak(BlockBreakEvent event)
-    {
-        if (!canModifyWorld(event.getPlayer(), true))
-        {
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onInteractWorld(PlayerInteractEvent event)
-    {
-        if (event.getInteractionPoint() != null && event.getInteractionPoint().getBlock().getBlockData() instanceof Openable) return;
-        if (!canModifyWorld(event.getPlayer(), true))
-        {
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onInteractWorld(PlayerInteractEntityEvent event)
-    {
-        if (!canModifyWorld(event.getPlayer(), true))
-        {
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onInteractWorld(PlayerItemDamageEvent event)
-    {
-        if (!canModifyWorld(event.getPlayer(), true))
-        {
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onInteractWorld(EntityDamageByEntityEvent event)
-    {
-        if (!(event.getDamager() instanceof Player player)) return;
-        if (!canModifyWorld(player, true))
-        {
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onEntitySpawn(EntitySpawnEvent event)
-    {
-        if (event.getEntityType() != EntityType.SLIME)
-        {
-            return;
-        }
-        event.setCancelled(true);
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST)
-    public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event)
-    {
-        // If the person has permission to modify the world, we don't need to block WorldEdit
-        if (canModifyWorld(event.getPlayer(), false))
-        {
-            return;
-        }
-
-        String message = event.getMessage();
-        // Don't check the arguments
-        message = message.replaceAll("\\s.*", "").replaceFirst("/", "");
-        Command command = Bukkit.getCommandMap().getCommand(message);
-        if (command != null)
-        {
-            // This does check for aliases
-            boolean isWeCommand = command instanceof PluginIdentifiableCommand && ((PluginIdentifiableCommand) command).getPlugin().equals(Bukkit.getPluginManager().getPlugin("WorldEdit"));
-            boolean isFaweCommand = command instanceof PluginIdentifiableCommand && ((PluginIdentifiableCommand) command).getPlugin().equals(Bukkit.getPluginManager().getPlugin("FastAsyncWorldEdit"));
-            if (isWeCommand || isFaweCommand || EDIT_COMMANDS.contains(message.toLowerCase()))
+            AtomicReference<Component> motd = new AtomicReference<>(Component.empty());
+            for (final String word : baseMotd.split(" "))
             {
-                String noEdit = plugin.config.getString("worlds." + world.getName().toLowerCase() + ".modification.message");
-                event.getPlayer().sendMessage(MiniMessage.miniMessage().deserialize(noEdit));
-                event.setCancelled(true);
+                motd.set(motd.get().append(Component.text(word).color(RandomUtil.getRandomColor())));
+                motd.set(motd.get().append(Component.space()));
+            }
+            event.motd(motd.get());
+        }
+        else
+        {
+            event.motd(PlexUtils.mmDeserialize(baseMotd.trim()));
+        }
+        if (plugin.config.contains("server.sample"))
+        {
+            List<String> samples = plugin.config.getStringList("server.sample");
+            if (!samples.isEmpty())
+            {
+                event.getPlayerSample().clear();
+                event.getPlayerSample().addAll(samples.stream().map(string -> string.replace("&", "§")).map(Bukkit::createProfile).toList());
             }
         }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onWorldTeleport(PlayerTeleportEvent event)
-    {
-        if (!canEnterWorld(event.getPlayer(), event.getTo().getWorld()))
-        {
-            event.setCancelled(true);
-        }
-    }
-
-    /**
-     * Check if a Player has the ability to modify the world they are in
-     *
-     * @param player      The player who wants to modify the world
-     * @param showMessage Whether the message from the config.yml should be shown
-     * @return Returns true if the person has the ability to modify the world
-     */
-    private boolean canModifyWorld(Player player, boolean showMessage)
-    {
-        World world = player.getWorld();
-        String permission = plugin.config.getString("worlds." + world.getName().toLowerCase() + ".modification.permission");
-        if (permission == null)
-        {
-            return true;
-        }
-        if (player.hasPermission(permission))
-        {
-            return true;
-        }
-
-        if (showMessage)
-        {
-            String noEdit = plugin.config.getString("worlds." + world.getName().toLowerCase() + ".modification.message");
-            if (noEdit != null)
-            {
-                player.sendMessage(MiniMessage.miniMessage().deserialize(noEdit));
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Check if a Player has the ability to enter the requested world
-     *
-     * @param player The player who wants to enter the world
-     * @return Returns true if the person has the ability to enter the world
-     */
-    private boolean canEnterWorld(Player player, World destination)
-    {
-        String permission = plugin.config.getString("worlds." + destination.getName().toLowerCase() + ".entry.permission");
-        if (permission == null)
-        {
-            return true;
-        }
-        if (player.hasPermission(permission))
-        {
-            return true;
-        }
-
-        String noEntry = plugin.config.getString("worlds." + destination.getName().toLowerCase() + ".entry.message");
-        if (noEntry != null)
-        {
-            player.sendMessage(MiniMessage.miniMessage().deserialize(noEntry));
-        }
-        return false;
     }
 }

--- a/server/src/main/java/dev/plex/listener/impl/WorldListener.java
+++ b/server/src/main/java/dev/plex/listener/impl/WorldListener.java
@@ -112,7 +112,8 @@ public class WorldListener extends PlexListener
             boolean isFaweCommand = command instanceof PluginIdentifiableCommand && ((PluginIdentifiableCommand) command).getPlugin().equals(Bukkit.getPluginManager().getPlugin("FastAsyncWorldEdit"));
             if (isWeCommand || isFaweCommand || EDIT_COMMANDS.contains(message.toLowerCase()))
             {
-                event.getPlayer().sendMessage(Component.text("You do not have permission to use that command in this world.").color(NamedTextColor.RED));
+                String noEdit = plugin.config.getString("worlds." + event.getPlayer().getWorld().getName().toLowerCase() + ".modification.message");
+                event.getPlayer().sendMessage(MiniMessage.miniMessage().deserialize(noEdit));
                 event.setCancelled(true);
             }
         }

--- a/server/src/main/java/dev/plex/services/impl/BanService.java
+++ b/server/src/main/java/dev/plex/services/impl/BanService.java
@@ -3,6 +3,7 @@ package dev.plex.services.impl;
 import dev.plex.Plex;
 import dev.plex.services.AbstractService;
 import dev.plex.util.TimeUtils;
+import dev.plex.util.PlexUtils;
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
@@ -27,7 +28,7 @@ public class BanService extends AbstractService
                 if (ZonedDateTime.now(ZoneId.of(TimeUtils.TIMEZONE)).isAfter(punishment.getEndDate()))
                 {
                     Plex.get().getPunishmentManager().unban(punishment);
-                    Bukkit.broadcast(Component.text("Plex - Unbanned " + Bukkit.getOfflinePlayer(punishment.getPunished()).getName()));
+                    Bukkit.broadcast(PlexUtils.messageComponent("banExpiredBroadcast", Bukkit.getOfflinePlayer(punishment.getPunished()).getName()));
                 }
             });
         });

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -27,6 +27,8 @@ indefBanMessageReason: "<red>Your {0} is indefinitely banned! You may appeal at 
 playerNotFound: "<red>Player not found!"
 specifyPlayer: "<red>You must specify a player!"
 worldNotFound: "<red>World not found!"
+# This will always be used for punishments where the sanctioning administrator has not provided a reason. Will ignore MiniMessage tags.
+noReasonProvided: "No reason provided."
 # 0 - The world you have been teleported to
 playerWorldTeleport: "<aqua>You have been teleported to {0}."
 # 0 - The person who is freezing
@@ -210,3 +212,41 @@ playersMaterialCleared: "<gray>{0} has been removed from the following players: 
 nobodyHasThatMaterial: "<gray>No one online has that in their inventory."
 # 0 - The attempted material name
 materialNotFound: "<red>{0} is not a valid item/block name."
+# 0 - The players name
+loginMessage: "<yellow>{0} joined the game"
+# 0 - The string that wasn't a valid integer
+notANumber: "<red>{0} is not a valid number!"
+# 0 - Players currently online
+# 1 - Max players
+listHeader: "<gray>There is currently <yellow>{0}<gray> player online out of <yellow>{1}<gray> players."
+# 0 - Players currently online
+# 1 - Max players
+listHeaderPlural: "<gray>There are currently <yellow>{0}<gray> players online out of <yellow>{1}<gray> players."
+# 0 - Player who is having their notes fetched
+notesHeader: "Player notes for: <green>{0}"
+# 0 - Note ID
+# 1 - Author of the note
+# 2 - Timestamp
+notePrefix: "<gold><!italic>{0} - Written by: {1} on {2}"
+# 0 - The content of the note
+noteLine: "<newline><yellow># {0}"
+# 0 - The player
+# 1 - The number of notes logged for said player
+playerNoteAlert: "<gold>{0} has {1} note. <click:run_command:/notes {0} list><underlined>Click here to view their note."
+# 0 - The player
+# 1 - The number of notes logged for said player
+playerNoteAlertPlural: "<gold>{0} has {1} notes. <click:run_command:/notes {0} list><underlined>Click here to view their notes."
+smiteTitleHeader: "<red>You've been smitten."
+# 0 - The reason for the smite. Will default to noReasonProvided if no reason is specified.
+# 1 - The admin / staff member
+smiteTitleMessage: "<yellow>Be sure to follow the rules!"
+# 0 - The player
+# 1 - The reason for the smite. Will default to noReasonProvided if no reason is specified.
+# 2 - The admin / staff member
+smiteBroadcast: "<red>{0} has been smitten!<newline><red> - Reason: <yellow>{1}<newline><red> - Smitten by: <yellow>{2}"
+# 0 - The player
+smittenQuietly: "<gray>Smitten {0} quietly."
+# 0 - The reason for being smitten
+smitten: "<red>You've been smitten. Reason: <yellow>{0}"
+nukerKickMessage: "Please turn off your nuker!"
+antiSpamMessage: "<gray>Please refrain from spamming messages."

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -250,3 +250,13 @@ smittenQuietly: "<gray>Smitten {0} quietly."
 smitten: "<red>You've been smitten. Reason: <yellow>{0}"
 nukerKickMessage: "Please turn off your nuker!"
 antiSpamMessage: "<gray>Please refrain from spamming messages."
+# 0 - The player
+banExpiredBroadcast: "Plex - Automatically unbanning {0}"
+# 0 - The player
+redisResetSuccessful: "<yellow>Successfuly reset {0}'s Redis punishments!"
+redisResetPlayerNotFound: "Couldn't find player in Redis punishments."
+reappliedGamerules: "<aqua>All game rules have been re-applied!"
+commandNotFound: "<red>That command could not be found!"
+# 0 - The command
+# 1 - A list of aliases found
+commandAliases: "<aqua>Aliases for {0} are: {1}"

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -243,7 +243,7 @@ smiteTitleMessage: "<yellow>Be sure to follow the rules!"
 # 0 - The player
 # 1 - The reason for the smite. Will default to noReasonProvided if no reason is specified.
 # 2 - The admin / staff member
-smiteBroadcast: "<red>{0} has been smitten!<newline><red> - Reason: <yellow>{1}<newline><red> - Smitten by: <yellow>{2}"
+smiteBroadcast: "<red>{0} has been a naughty, naughty boy.<newline><red> - Reason: <yellow>{1}<newline><red> - Smitten by: <yellow>{2}"
 # 0 - The player
 smittenQuietly: "<gray>Smitten {0} quietly."
 # 0 - The reason for being smitten


### PR DESCRIPTION
Some notes: I've changed the default header for the smite command broadcast to "X has been smitten!" It doesn't make sense to force the current version which is "X has been a naughty naughty boy" on servers using Plex, since it's a TF specific joke. I've also added some functionality to the title message shown to the "smitee".

This PR also isn't finished, I'm making this draft so the maintainers here can review my current changes.