### PR TITLE
Utilise the new Prism API

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 repositories {
     maven(url = uri("https://maven.playpro.com"))
     maven(url = uri("https://nexus.telesphoreo.me/repository/plex-modules/"))
+    maven(url = uri("https://nexus.prism-mc.org/repository/maven-snapshots/"))
 }
 
 dependencies {
@@ -24,7 +25,7 @@ dependencies {
         exclude("org.bukkit", "bukkit")
     }
     compileOnly("net.coreprotect:coreprotect:23.2")
-    compileOnly("network.darkhelmet.prism:Prism-Api:1.0.0")
+    compileOnly("org.prism_mc.prism:prism-paper-api:4.3-SNAPSHOT")
     compileOnly("com.github.LeonMangler:SuperVanish:6.2.19")
     implementation("org.bstats:bstats-base:3.2.1")
     implementation("org.bstats:bstats-bukkit:3.2.1")
@@ -60,7 +61,7 @@ paper {
             required = false
             load = PaperPluginDescription.RelativeLoadOrder.BEFORE
         }
-        register("Prism") {
+        register("prism") {
             required = false
             load = PaperPluginDescription.RelativeLoadOrder.BEFORE
         }

--- a/server/src/main/java/dev/plex/command/impl/BanCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/BanCMD.java
@@ -14,8 +14,10 @@ import dev.plex.util.PlexLog;
 import dev.plex.util.PlexUtils;
 import dev.plex.util.TimeUtils;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -26,6 +28,10 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.prism_mc.prism.api.activities.Activity;
+import org.prism_mc.prism.api.activities.ActivityQuery;
+import org.prism_mc.prism.paper.api.PrismPaperApi;
+import org.prism_mc.prism.paper.api.activities.PaperActivityQuery;
 
 @CommandParameters(name = "ban", usage = "/<command> <player> [reason] [-rb]", aliases = "offlineban,gtfo", description = "Bans a player, offline or online")
 @CommandPermissions(permission = "plex.ban", source = RequiredCommandSource.ANY)
@@ -90,33 +96,30 @@ public class BanCMD extends PlexCommand
 
             if (rollBack)
             {
-                /*if (plugin.getPrismHook() != null && plugin.getPrismHook().hasPrism())
+                if (plugin.getPrismHook() != null && plugin.getPrismHook().hasPrism())
                 {
-                    PrismParameters parameters = plugin.getPrismHook().prismApi().createParameters();
-                    parameters.addActionType("block-place");
-                    parameters.addActionType("block-break");
-                    parameters.addActionType("block-burn");
-                    parameters.addActionType("entity-spawn");
-                    parameters.addActionType("entity-kill");
-                    parameters.addActionType("entity-explode");
-                    parameters.addPlayerName(plexPlayer.getName());
-                    parameters.setBeforeTime(Instant.now().toEpochMilli());
-                    parameters.setProcessType(PrismProcessType.ROLLBACK);
-                    final Future<Result> result = plugin.getPrismHook().prismApi().performLookup(parameters, sender);
-                    Bukkit.getAsyncScheduler().runNow(plugin, scheduledTask ->
+                    PrismPaperApi prism = plugin.getPrismHook().getPrism();
+                    Bukkit.getAsyncScheduler().runNow(plugin, task ->
                     {
                         try
                         {
-                            final Result done = result.get();
+                            ActivityQuery query = PaperActivityQuery.builder()
+                                    .actionTypeKeys(Arrays.asList("block-place", "block-break", "block-burn", "entity-spawn", "entity-kill", "entity-explode"))
+                                    .causePlayerName(plexPlayer.getName())
+                                    .before(Instant.now().getEpochSecond())
+                                    .rollback()
+                                    .build();
+
+                            List<Activity> activities = prism.storageAdapter().queryActivities(query);
+                            PlexLog.debug("{0} activities have been rollback", activities.size());
                         }
-                        catch (InterruptedException | ExecutionException e)
+                        catch (Exception ex)
                         {
-                            throw new RuntimeException(e);
+                            PlexLog.error("Unable to query activities: {0}", ex);
                         }
                     });
                 }
-                else */
-                if (plugin.getCoreProtectHook() != null && plugin.getCoreProtectHook().hasCoreProtect())
+                else if (plugin.getCoreProtectHook() != null && plugin.getCoreProtectHook().hasCoreProtect())
                 {
                     Bukkit.getAsyncScheduler().runNow(plugin, scheduledTask ->
                     {

--- a/server/src/main/java/dev/plex/command/impl/BanCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/BanCMD.java
@@ -102,6 +102,7 @@ public class BanCMD extends PlexCommand
                             .actionTypeKeys(Arrays.asList("block-place", "block-break", "block-burn", "entity-spawn", "entity-kill", "entity-explode"))
                             .causePlayerName(plexPlayer.getName())
                             .before(Instant.now().getEpochSecond())
+                            .after(Instant.now().getEpochSecond() - 86400)
                             .rollback()
                             .build();
                     prism.rollback(sender, query).whenCompleteAsync((result, error) -> {

--- a/server/src/main/java/dev/plex/command/impl/BanCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/BanCMD.java
@@ -105,15 +105,18 @@ public class BanCMD extends PlexCommand
                             .after(Instant.now().getEpochSecond() - 86400)
                             .rollback()
                             .build();
-                    prism.rollback(sender, query).whenCompleteAsync((result, error) -> {
-                        if (error != null) {
+                    prism.rollback(sender, query).whenCompleteAsync((result, error) ->
+                    {
+                        if (error != null)
+                        {
                             send(sender, messageComponent("prismRollbackError", error.getMessage()));
                             PlexLog.error("Unable to rollback: {0}", error);
                             return;
                         }
 
                         int count = result.applied();
-                        if (count == 0) {
+                        if (count == 0)
+                        {
                             send(sender, messageComponent("prismNoResult", count));
                             PlexLog.debug("No activities are available to rollback");
                             return;

--- a/server/src/main/java/dev/plex/command/impl/BanCMD.java
+++ b/server/src/main/java/dev/plex/command/impl/BanCMD.java
@@ -28,7 +28,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.prism_mc.prism.api.activities.Activity;
 import org.prism_mc.prism.api.activities.ActivityQuery;
 import org.prism_mc.prism.paper.api.PrismPaperApi;
 import org.prism_mc.prism.paper.api.activities.PaperActivityQuery;
@@ -99,24 +98,28 @@ public class BanCMD extends PlexCommand
                 if (plugin.getPrismHook() != null && plugin.getPrismHook().hasPrism())
                 {
                     PrismPaperApi prism = plugin.getPrismHook().getPrism();
-                    Bukkit.getAsyncScheduler().runNow(plugin, task ->
-                    {
-                        try
-                        {
-                            ActivityQuery query = PaperActivityQuery.builder()
-                                    .actionTypeKeys(Arrays.asList("block-place", "block-break", "block-burn", "entity-spawn", "entity-kill", "entity-explode"))
-                                    .causePlayerName(plexPlayer.getName())
-                                    .before(Instant.now().getEpochSecond())
-                                    .rollback()
-                                    .build();
+                    ActivityQuery query = PaperActivityQuery.builder()
+                            .actionTypeKeys(Arrays.asList("block-place", "block-break", "block-burn", "entity-spawn", "entity-kill", "entity-explode"))
+                            .causePlayerName(plexPlayer.getName())
+                            .before(Instant.now().getEpochSecond())
+                            .rollback()
+                            .build();
+                    prism.rollback(sender, query).whenCompleteAsync((result, error) -> {
+                        if (error != null) {
+                            send(sender, messageComponent("prismRollbackError", error.getMessage()));
+                            PlexLog.error("Unable to rollback: {0}", error);
+                            return;
+                        }
 
-                            List<Activity> activities = prism.storageAdapter().queryActivities(query);
-                            PlexLog.debug("{0} activities have been rollback", activities.size());
+                        int count = result.applied();
+                        if (count == 0) {
+                            send(sender, messageComponent("prismNoResult", count));
+                            PlexLog.debug("No activities are available to rollback");
+                            return;
                         }
-                        catch (Exception ex)
-                        {
-                            PlexLog.error("Unable to query activities: {0}", ex);
-                        }
+
+                        send(sender, messageComponent("prismRollbackMessage", count));
+                        PlexLog.debug("Rolled back {0} activities", count);
                     });
                 }
                 else if (plugin.getCoreProtectHook() != null && plugin.getCoreProtectHook().hasCoreProtect())

--- a/server/src/main/java/dev/plex/hook/PrismHook.java
+++ b/server/src/main/java/dev/plex/hook/PrismHook.java
@@ -1,12 +1,14 @@
 package dev.plex.hook;
 
 import dev.plex.Plex;
-import network.darkhelmet.prism.api.PrismApi;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.RegisteredServiceProvider;
+import org.prism_mc.prism.paper.api.PrismPaperApi;
 
 public class PrismHook
 {
-    private PrismApi prismApi;
+    private RegisteredServiceProvider<PrismPaperApi> provider;
 
     public PrismHook(Plex plex)
     {
@@ -18,18 +20,17 @@ public class PrismHook
             return;
         }
 
-        // Check that the API is enabled
-        this.prismApi = (PrismApi) plugin;
+        provider = Bukkit.getServicesManager().getRegistration(PrismPaperApi.class);
     }
 
     public boolean hasPrism()
     {
-        return prismApi != null;
+        return provider != null;
     }
 
-    public PrismApi prismApi()
+    public PrismPaperApi getPrism()
     {
-        return prismApi;
+        return provider.getProvider();
     }
 }
 

--- a/server/src/main/resources/messages.yml
+++ b/server/src/main/resources/messages.yml
@@ -280,3 +280,8 @@ commandNotFound: "<red>That command could not be found!"
 # 0 - The command
 # 1 - A list of aliases found
 commandAliases: "<aqua>Aliases for {0} are: {1}"
+# 0 - Number of activities found to rollback
+prismRollbackMessage: "<gray>Rolled back {0} activities"
+# 0 - Error message returned from Prism
+prismRollbackError: "<red>Rollback failed: {0}"
+prismNoResult: "<gray>No activities have been rolled back"


### PR DESCRIPTION
Since Prism introduced the new API from `v4.3` (and modification services in upcoming `v4.4`), we should be taking advantage of what it offers.

At the moment, we're only using the API for bans to rollback activities.