### PR TITLE
Fix module-owned resource lookup

### DIFF
--- a/api/src/main/java/dev/plex/module/PlexModule.java
+++ b/api/src/main/java/dev/plex/module/PlexModule.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.List;
@@ -163,7 +164,11 @@ public abstract class PlexModule
     }
 
     /**
-     * Opens a resource from this module's class loader.
+     * Opens a resource owned by this module.
+     *
+     * <p>Plex module class loaders delegate to Plex's class loader. This method
+     * searches the module class loader itself first so common paths such as
+     * {@code config.yml} cannot resolve to a resource bundled by Plex.</p>
      *
      * @param filename resource path
      * @return resource stream, or {@code null} when the resource cannot be opened
@@ -173,7 +178,10 @@ public abstract class PlexModule
     {
         try
         {
-            URL url = this.getClass().getClassLoader().getResource(filename);
+            ClassLoader classLoader = this.getClass().getClassLoader();
+            URL url = classLoader instanceof URLClassLoader moduleClassLoader
+                    ? moduleClassLoader.findResource(filename)
+                    : classLoader.getResource(filename);
             if (url == null)
             {
                 return null;

--- a/server/src/main/java/dev/plex/api/impl/ServerModuleConfiguration.java
+++ b/server/src/main/java/dev/plex/api/impl/ServerModuleConfiguration.java
@@ -31,7 +31,7 @@ final class ServerModuleConfiguration extends ModuleConfiguration
     {
         try
         {
-            ConfigDefaultsMerger.Result result = ConfigDefaultsMerger.merge(file, module.getClass().getResourceAsStream("/" + from), to);
+            ConfigDefaultsMerger.Result result = ConfigDefaultsMerger.merge(file, module.getResource(from), to);
             if (!result.addedKeys().isEmpty())
             {
                 PlexLog.log("Merged default key(s) into " + to + ": " + String.join(", ", result.addedKeys()));
@@ -57,7 +57,7 @@ final class ServerModuleConfiguration extends ModuleConfiguration
         {
             File parent = file.getParentFile();
             if (parent != null) parent.mkdirs();
-            try (InputStream stream = module.getClass().getResourceAsStream("/" + from))
+            try (InputStream stream = module.getResource(from))
             {
                 if (stream == null)
                 {

--- a/server/src/main/java/dev/plex/storage/database/MigrationRunner.java
+++ b/server/src/main/java/dev/plex/storage/database/MigrationRunner.java
@@ -7,9 +7,6 @@ import dev.plex.util.PlexLog;
 import javax.sql.DataSource;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -131,7 +128,7 @@ public class MigrationRunner
     private String readModule(PlexModule module, String resourceRoot, String version) throws SQLException
     {
         String resource = resourceRoot + "/" + storageType.dialect().migrationDirectory() + "/" + version + ".sql";
-        try (InputStream stream = openModuleResource(module, resource))
+        try (InputStream stream = module.getResource(resource))
         {
             if (stream == null)
             {
@@ -143,32 +140,6 @@ public class MigrationRunner
         {
             throw new SQLException("Failed to read module migration resource: " + resource, e);
         }
-    }
-
-    /**
-     * Opens a migration resource from the module's own jar.
-     *
-     * <p>A module class loader is parent-first with the Plex class loader as its
-     * parent, and core ships migration scripts at the same
-     * {@code db/migration/<dialect>/<version>.sql} paths a module uses. A plain
-     * {@link PlexModule#getResource(String)} lookup therefore resolves to Plex's
-     * core script instead of the module's own. {@link URLClassLoader#findResource}
-     * searches only the module jar, so the module always reads its own migration.</p>
-     */
-    private InputStream openModuleResource(PlexModule module, String resource) throws IOException
-    {
-        if (module.getClass().getClassLoader() instanceof URLClassLoader moduleClassLoader)
-        {
-            URL url = moduleClassLoader.findResource(resource);
-            if (url == null)
-            {
-                return null;
-            }
-            URLConnection connection = url.openConnection();
-            connection.setUseCaches(false);
-            return connection.getInputStream();
-        }
-        return module.getResource(resource);
     }
 
     private String replaceTableTokens(String script, Function<String, String> tableResolver) throws SQLException


### PR DESCRIPTION
## Summary

- make `PlexModule.getResource()` search the requesting module JAR before Plex’s parent classloader
- route module configuration defaults through the corrected resource API
- consolidate the migration loader’s existing child-first workaround into `PlexModule.getResource()`

## Why

Plex module classloaders delegate to Plex first. When a module requests a common resource such as `config.yml`, the lookup can return Plex’s own bundled configuration instead of the file inside the module JAR. This prevents modules from safely using conventional resource names.

## Impact

Modules can bundle and load a normal `config.yml` without colliding with Plex resources. Existing module migration behavior remains child-first, now through the shared public API.

## Validation

- `./gradlew :api:javadoc :server:compileJava`
- Discord bridge `./gradlew clean build` with `config.yml` packaged in its JAR
- `git diff --check`